### PR TITLE
Closes #35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Define the project name and version
-project(GeruestLibrary VERSION 0.5.3 LANGUAGES CXX)
+project(GeruestLibrary VERSION 0.5.4 LANGUAGES CXX)
 
 # Configure version header
 configure_file(

--- a/src/builders/HTMLBuilder.cpp
+++ b/src/builders/HTMLBuilder.cpp
@@ -33,15 +33,32 @@ void HtmlBuilder::buildHtml() {
 
     // Build the HTML file
 
-    auto rootSize = (unsigned)root.size();
-    unsigned langStart = rootSize + 6;
-    unsigned langSize = 2;
-
-    // Get language from path
-    std::string language = path.substr(langStart, langSize);
-
-    // Get the template path
+    // Extract language from path more robustly
+    // Path format: /root/html/LANG/file.html or /root/html/file.html
+    std::string language;
     std::string templatePath = path;
+    
+    // Find /html/ in the path
+    size_t htmlPos = path.find("/html/");
+    if (htmlPos != std::string::npos) {
+        size_t afterHtml = htmlPos + 6; // Position after "/html/"
+        size_t nextSlash = path.find('/', afterHtml);
+        
+        if (nextSlash != std::string::npos) {
+            // Extract potential language code
+            std::string potentialLang = path.substr(afterHtml, nextSlash - afterHtml);
+            
+            // Check if it's a 2-character language code
+            if (potentialLang.length() == 2 && std::isalpha(potentialLang[0]) && std::isalpha(potentialLang[1])) {
+                language = potentialLang;
+            }
+        }
+    }
+    
+    // If no language detected, use default language
+    if (language.empty() && !availableLanguages.empty()) {
+        language = availableLanguages[0];
+    }
 
     // Check if the file exists with the language directory
     bool useLanguageSpecificFile = std::filesystem::exists(path);
@@ -50,8 +67,15 @@ void HtmlBuilder::buildHtml() {
         // File exists with language directory, use it directly
         builtFile = loadFile(path);
     } else {
-        // Load template file, remove language redirection
-        templatePath.erase(langStart, langSize + 1);  // remove the language part
+        // Load template file - remove language part from path
+        if (!language.empty() && htmlPos != std::string::npos) {
+            // Remove /LANG/ from the path to get template path
+            size_t langStart = htmlPos + 6; // After "/html/"
+            size_t langEnd = path.find('/', langStart);
+            if (langEnd != std::string::npos) {
+                templatePath = path.substr(0, langStart) + path.substr(langEnd + 1);
+            }
+        }
         builtFile = loadFile(templatePath);
     }
 

--- a/src/handler/Handler.cpp
+++ b/src/handler/Handler.cpp
@@ -446,14 +446,11 @@ std::string Handler::buildPath(std::string& pathReceived, const std::string& Ext
                     }
                 }
 
-                // Try language-specific paths
-                std::string langPath = serverData.getRoot() + "/html/" + preferredLang + "/index.html";
-                if (std::filesystem::exists(langPath)) {
-                    return langPath;
-                }
+                // Always return language-specific path - HTMLBuilder will handle building if needed
+                return serverData.getRoot() + "/html/" + preferredLang + "/index.html";
             }
 
-            // Fallback to simple index.html if language-specific doesn't exist or no languages configured
+            // Fallback to simple index.html if no languages configured
             return serverData.getRoot() + "/html/index.html";
         }
 
@@ -470,12 +467,9 @@ std::string Handler::buildPath(std::string& pathReceived, const std::string& Ext
                 }
             }
 
-            std::string langDir = serverData.getRoot() + "/html/" + preferredLang;
-            if (std::filesystem::exists(langDir)) {
-                contentRoot["html"] = "/html/" + preferredLang;
-            } else {
-                contentRoot["html"] = "/html";
-            }
+            // Always use language-specific path when languages are configured
+            // HTMLBuilder will handle loading from template if language file doesn't exist
+            contentRoot["html"] = "/html/" + preferredLang;
         } else {
             // No languages configured, use simple /html
             contentRoot["html"] = "/html";


### PR DESCRIPTION
This pull request updates the project version and refactors how language-specific HTML files are handled, making the language extraction from paths more robust and delegating fallback logic to the HTML builder. The main improvements are in the detection and handling of language codes in file paths, as well as simplifying the responsibilities between the handler and HTML builder.

**Language detection and handling improvements:**

* Refactored language extraction logic in `HTMLBuilder.cpp` to robustly parse language codes from the file path, supporting both language-specific and default paths, and falling back to a default language if none is detected.
* Updated template path handling in `HTMLBuilder.cpp` to correctly remove the language part from the path when loading the template file, ensuring the correct file is loaded regardless of language presence.

**Handler logic simplification:**

* Changed `Handler.cpp` to always return the language-specific path for HTML files when languages are configured, letting the HTML builder handle the case when the file doesn't exist, instead of checking for file existence in the handler.
* Simplified logic in `Handler.cpp` to always set the content root to the language-specific directory when languages are configured, deferring existence checks to the HTML builder.

**Project version update:**

* Updated project version from `0.5.3` to `0.5.4` in `CMakeLists.txt`.…in HTMLBuilder