### PR TITLE
v0.10.6 — WebSocket support and bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 # Define the project name and version
-project(GeruestLibrary VERSION 0.9.26 LANGUAGES CXX)
+project(GeruestLibrary VERSION 0.10.1 LANGUAGES CXX)
 
 # Configure version header
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 # Define the project name and version
-project(GeruestLibrary VERSION 0.10.1 LANGUAGES CXX)
+project(GeruestLibrary VERSION 0.10.2 LANGUAGES CXX)
 
 # Configure version header
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 # Define the project name and version
-project(GeruestLibrary VERSION 0.10.6 LANGUAGES CXX)
+project(GeruestLibrary VERSION 0.10.7 LANGUAGES CXX)
 
 # Configure version header
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 # Define the project name and version
-project(GeruestLibrary VERSION 0.10.5 LANGUAGES CXX)
+project(GeruestLibrary VERSION 0.10.6 LANGUAGES CXX)
 
 # Configure version header
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 # Define the project name and version
-project(GeruestLibrary VERSION 0.10.3 LANGUAGES CXX)
+project(GeruestLibrary VERSION 0.10.4 LANGUAGES CXX)
 
 # Configure version header
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 # Define the project name and version
-project(GeruestLibrary VERSION 0.10.4 LANGUAGES CXX)
+project(GeruestLibrary VERSION 0.10.5 LANGUAGES CXX)
 
 # Configure version header
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 # Define the project name and version
-project(GeruestLibrary VERSION 0.10.2 LANGUAGES CXX)
+project(GeruestLibrary VERSION 0.10.3 LANGUAGES CXX)
 
 # Configure version header
 configure_file(
@@ -101,6 +101,7 @@ add_library(Geruest STATIC
     src/server/Socket.cpp
     src/server/Workers.cpp
     src/server/HttpSession.cpp
+    src/server/WebSocket.cpp
     src/server/Status.cpp
     src/auth/BasicAuth.cpp
     src/builders/AssetMerger.cpp

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -36,6 +36,9 @@ POSTGRES_DB=app
 POSTGRES_USER=app
 POSTGRES_PASSWORD=secret
 POSTGRES_SSLMODE=prefer
+POSTGRES_CONNECT_TIMEOUT=5
+POSTGRES_STATEMENT_TIMEOUT_MS=30000
+POSTGRES_PIPELINE_MAX_BATCH=8
 
 # Feature Flags
 DEV_MODE=false
@@ -96,7 +99,7 @@ Selection precedence is:
 2. environment /.env `DATABASE_BACKEND`
 3. default `none`
 
-If selected backend is not compiled in (`GERUEST_HAS_LIBPQ=0` or `GERUEST_HAS_SQLITE=0`), startup fails fast.
+If the selected backend is not compiled in (`GERUEST_HAS_LIBPQ=0` or `GERUEST_HAS_SQLITE=0`), initialization throws. If the backend is compiled in but required settings are missing (empty `POSTGRES_DB`/`POSTGRES_USER` for Postgres, empty `SQLITE_PATH` for SQLite), Geruest logs an error and leaves the database client unset (`HTTPRequest::database()` stays null). See [DATABASE.md](DATABASE.md).
 
 ### Server Configuration
 

--- a/doc/DATABASE.md
+++ b/doc/DATABASE.md
@@ -21,12 +21,16 @@ cmake -S . -B build -DGERUEST_ENABLE_POSTGRESQL=ON -DGERUEST_ENABLE_SQLITE=ON
 cmake --build build
 ```
 
+If a backend option is `ON` but the dependency is not found (no `libpq-dev` / `libsqlite3-dev`), CMake continues with that backend disabled and `GERUEST_HAS_*` stays `0`.
+
 Compile-time flags exposed to users:
 
 - `GERUEST_HAS_LIBPQ` (0/1)
 - `GERUEST_HAS_SQLITE` (0/1)
 
 ## Runtime Configuration (.env)
+
+Keys below are read when `Geruest::loadConfig(...)` runs (or your app uses `ConfigLoader` the same way). PostgreSQL keys apply only when `DATABASE_BACKEND=postgres`; SQLite keys when `DATABASE_BACKEND=sqlite`.
 
 ```env
 DATABASE_BACKEND=sqlite
@@ -36,24 +40,32 @@ SQLITE_PATH=./geruest.db
 SQLITE_BUSY_TIMEOUT_MS=5000
 SQLITE_DB_EXECUTOR_THREADS=1
 
-# PostgreSQL (used only when DATABASE_BACKEND=postgres)
+# PostgreSQL (only when DATABASE_BACKEND=postgres)
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=app
 POSTGRES_USER=app
 POSTGRES_PASSWORD=secret
 POSTGRES_SSLMODE=prefer
+POSTGRES_CONNECT_TIMEOUT=5
+POSTGRES_STATEMENT_TIMEOUT_MS=30000
+# libpq pipeline batch size per worker (1 = pipeline off, max 256)
+POSTGRES_PIPELINE_MAX_BATCH=8
 ```
 
 Selection precedence:
 
-1. code setter (`setDatabaseBackend(...)`)
-2. `DATABASE_BACKEND` env/.env
-3. default `none`
+1. Code setters (`setDatabaseBackend`, `setDatabasePoolSize`, `setSqliteExecutorThreadCount`, `configurePostgres`, `configureSqlite`) — each field tracks whether it was set; setters override env/.env for that field.
+2. `DATABASE_BACKEND` and other keys from environment / `.env` (via `ConfigLoader`).
+3. Built-in defaults (`DATABASE_BACKEND` default `none`, pool size `4`, one SQLite executor thread, etc.).
 
-If selected backend is not compiled in, startup fails fast.
+If `DATABASE_BACKEND` selects Postgres or SQLite but that backend was **not** compiled in (`GERUEST_HAS_LIBPQ=0` or `GERUEST_HAS_SQLITE=0`), `initializeDatabaseFromConfig()` throws and startup aborts.
+
+If the backend **is** compiled in but **required connection settings are missing** (`POSTGRES_DB` or `POSTGRES_USER` empty for Postgres; `SQLITE_PATH` empty for SQLite), Geruest logs an error and leaves the shared database client unset. Then `request.database()` is null until you fix configuration — no exception in that path.
 
 ## Runtime Configuration (Code API)
+
+`#include "Geruest.hpp"` pulls in `database/DatabaseClient.hpp` (types in namespace `geruest::db`). `configurePostgres` / `configureSqlite` are declared only when the matching `GERUEST_HAS_*` compile definition is `1`.
 
 ```cpp
 geruest::Geruest server;
@@ -69,7 +81,7 @@ sqliteCfg.busyTimeoutMs = 5000;
 server.configureSqlite(sqliteCfg);
 #endif
 
-server.loadConfig(".env"); // optional: still loads unset values
+server.loadConfig(".env"); // fills any fields not already locked by setters/configure*
 ```
 
 For PostgreSQL:
@@ -85,6 +97,11 @@ pg.database = "app";
 pg.user = "app";
 pg.password = "secret";
 pg.sslmode = "prefer";
+pg.connectTimeoutSeconds = 5;
+pg.statementTimeoutMs = 30000;
+pg.maxPipelineBatch = 8;  // 1 disables pipelining
+// Optional tuning (not loaded from .env today):
+// pg.tcpKeepalives, pg.keepalivesIdleSeconds, ...
 server.configurePostgres(pg);
 #endif
 ```
@@ -142,13 +159,17 @@ std::uint64_t affected = co_await db->executeAsync(
 
 ## Parameter Binding
 
-- Always pass values in `params` vector.
+- Always pass values in the `params` vector (`std::vector<geruest::db::BindValue>`).
 - Do not concatenate user input into SQL strings.
-- Supported bind value types:
-  - `nullptr`
-  - `std::int64_t`
-  - `double`
-  - `std::string`
+- `BindValue` is `std::variant<std::nullptr_t, std::int64_t, double, std::string>` — supported values: `nullptr`, integer, floating-point, and string.
+
+## Query and execute results
+
+- `queryAsync` returns `geruest::db::QueryResult`:
+  - `columnNames` — names in column order (empty for statements with no result set).
+  - `rows` — each `QueryRow` has `columns` as strings (SQLite `NULL` becomes empty string).
+  - `affectedRows` — rows changed / command tag where applicable; `executeAsync` returns this same count as `std::uint64_t`.
+- `DatabaseClient::backend()` returns `geruest::db::Backend` (`None`, `Postgres`, `Sqlite`) for the concrete client implementation.
 
 ## SQLite Notes
 
@@ -159,11 +180,14 @@ std::uint64_t affected = co_await db->executeAsync(
 
 ## PostgreSQL Notes
 
-- Uses libpq backend when compiled with `GERUEST_ENABLE_POSTGRESQL=ON`.
-- Configure host/port/db/user/password/sslmode via code or `.env`.
+- Uses libpq when built with `GERUEST_ENABLE_POSTGRESQL=ON` and `find_package(PostgreSQL)` succeeds.
+- Connection string includes `connect_timeout` from `POSTGRES_CONNECT_TIMEOUT` / `PostgresConfig::connectTimeoutSeconds`.
+- Each pooled connection sets `statement_timeout` from `POSTGRES_STATEMENT_TIMEOUT_MS` / `PostgresConfig::statementTimeoutMs`.
+- Workers can batch multiple queued statements with libpq pipelining; batch size is capped by `POSTGRES_PIPELINE_MAX_BATCH` (clamped to 1–256). Use `1` to disable pipelining.
+- TCP keepalive fields on `PostgresConfig` default to on; tune them only from C++ (not currently read from `.env`).
 
 ## Troubleshooting
 
-- **No DB available in route**: `request.database()` is null. Check `DATABASE_BACKEND` and backend compile flags.
-- **Startup throws backend not compiled**: selected backend requires build option ON and matching dev package.
-- **SQLite test missing**: configure tests with `-DGERUEST_ENABLE_SQLITE=ON`.
+- **`request.database()` is null**: `DATABASE_BACKEND` is `none`, the library was built without that backend, or Postgres/SQLite was selected but mandatory settings were missing (see logs: empty `POSTGRES_DB`/`POSTGRES_USER`, or empty `SQLITE_PATH`).
+- **Startup throws “built without PostgreSQL/SQLite support”**: enable the backend in CMake and install `libpq-dev` / `libsqlite3-dev` so `GERUEST_HAS_LIBPQ` / `GERUEST_HAS_SQLITE` become `1`.
+- **SQLite unit tests skipped or missing**: build the library with `-DGERUEST_ENABLE_SQLITE=ON` and see `src/unitTests/README.md` / Postgres docker notes in `src/unitTests/CMakeLists.txt` for integration tests.

--- a/doc/DATA_CLASSES.md
+++ b/doc/DATA_CLASSES.md
@@ -38,6 +38,36 @@ server.addRoute("/search", [](const HTTPRequest& req) {
 });
 ```
 
+## WebSocketConnection
+
+Persistent connection after HTTP upgrade. Used with `addRouteWebSocket`.
+
+**Coroutine methods:**
+```cpp
+boost::asio::awaitable<WSMessage> recv();
+boost::asio::awaitable<void> send(std::string_view text);
+boost::asio::awaitable<void> sendBinary(std::span<const uint8_t> data);
+boost::asio::awaitable<void> close(uint16_t code = 1000, std::string_view reason = "");
+bool isOpen() const;
+```
+
+**Callback helpers:** `sendNow()`, `sendBinaryNow()` — fire-and-forget from `WebSocketRoute` callbacks.
+
+**Route registration:**
+```cpp
+// Coroutine
+server.addRouteWebSocket("/ws", handler);
+
+// Callback struct
+geruest::WebSocketRoute route;
+route.onOpen = ...;
+route.onMessage = ...;
+route.onClose = ...;
+server.addRouteWebSocket("/ws-cb", route);
+```
+
+See [WEBSOCKETS.md](WEBSOCKETS.md) for full examples.
+
 ## HTTPResponse
 
 Build HTTP responses.

--- a/doc/DATA_CLASSES.md
+++ b/doc/DATA_CLASSES.md
@@ -12,6 +12,9 @@ std::string getPath(size_t idx) const;          // Path segment at index
 const std::string& getClientIP() const;         // Client IP address
 const std::string& getBody() const;             // Request body
 
+// Shared database client (async routes); null if backend is none or initialization failed
+std::shared_ptr<geruest::db::DatabaseClient> database() const;
+
 // Query parameters
 bool hasParam(const std::string& name) const;
 std::string getParam(const std::string& name) const;

--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -4,7 +4,7 @@
 
 | Feature | Description | Key Method/Header |
 |---------|-------------|-------------------|
-| **Routing** | Sync (`addRoute`) and async (`addRouteAsync`) handlers with exact/wildcard paths | `addRoute()`, `addRouteAsync()` |
+| **Routing** | Sync (`addRoute`), async (`addRouteAsync`), and WebSocket (`addRouteWebSocket`) handlers with exact/wildcard paths | `addRoute()`, `addRouteAsync()`, `addRouteWebSocket()` |
 | **Static Files** | Auto-serve files from root directories | `addRoot()` |
 | **Templates** | Component injection `{file}`, translations `[key]` | `ContentBuilder` |
 | **Asset Merging** | Combine CSS/JS files from file maps | `AssetMerger` |
@@ -29,7 +29,7 @@ The HTTP server is built on **Boost.Asio**:
 
 ## Routing
 
-Use `addRoute` for sync handlers and `addRouteAsync` when you need `co_await` (DB/network/waitable work).
+Use `addRoute` for sync handlers, `addRouteAsync` when you need `co_await` (DB/network/waitable work), and `addRouteWebSocket` for persistent WebSocket connections. See [WebSockets](WEBSOCKETS.md).
 
 ```cpp
 // Exact match (O(1) lookup)

--- a/doc/README.md
+++ b/doc/README.md
@@ -16,6 +16,7 @@ Welcome to the Geruest documentation! This guide will help you get started with 
 - [**Redirects and 404**](REDIRECTS_AND_404.md) - Redirect maps, wildcard redirects, and custom 404 pages
 - [**Data Classes**](DATA_CLASSES.md) - HTTPRequest, HTTPResponse, JSONParser API reference
 - [**Database Usage**](DATABASE.md) - Async DB setup and route usage (PostgreSQL/SQLite)
+- [**WebSockets**](WEBSOCKETS.md) - `addRouteWebSocket` coroutine and callback APIs
 
 ### Template System
 

--- a/doc/REDIRECTS_AND_404.md
+++ b/doc/REDIRECTS_AND_404.md
@@ -49,6 +49,9 @@ Notes:
 
 - Wildcard forwarding uses the matched `*` segment from the source path.
 - The most specific wildcard pattern wins when several match.
+- With languages enabled, requests with language prefixes keep that prefix for internal redirect targets that do not already declare a language.
+  - Example: `/de/path/redirect` with `*/redirect -> /redirection` resolves to `/de/redirection`.
+  - If target already contains language (example `/en/redirection`), configured target is kept unchanged.
 
 ### Bulk Redirects (Map)
 
@@ -80,6 +83,15 @@ Request handling priority is:
 6. 404 response
 
 This makes short-link redirects predictable and keeps redirect behavior deterministic.
+
+## Redirects with Languages
+
+When `setAvailableLanguages(...)` is configured:
+
+- Exact and wildcard redirects can match language-prefixed request paths even if redirect source was configured without language.
+  - Example: configured `/something -> /redirection`, request `/de/something` redirects to `/de/redirection`.
+- Internal targets without explicit language inherit language from request path.
+- External targets (`http://`, `https://`, `//`) are never modified.
 
 ## Loop Protection
 

--- a/doc/USAGE_GUIDE.md
+++ b/doc/USAGE_GUIDE.md
@@ -110,6 +110,21 @@ server {
 }
 ```
 
+## WebSockets
+
+Register with `addRouteWebSocket` (coroutine or callback API). See [WEBSOCKETS.md](WEBSOCKETS.md).
+
+For nginx WSS termination, proxy with upgrade headers:
+
+```nginx
+location /echo {
+    proxy_pass http://backend;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+}
+```
+
 ## Configuration
 
 ```cpp

--- a/doc/WEBSOCKETS.md
+++ b/doc/WEBSOCKETS.md
@@ -1,0 +1,66 @@
+# WebSockets
+
+Geruest supports RFC 6455 WebSockets alongside existing HTTP routes. Register handlers with `addRouteWebSocket` — same path matching as `addRoute` / `addRouteAsync` (exact and `*` wildcards).
+
+## Coroutine API (recommended)
+
+Mirrors `addRouteAsync`: handler returns `boost::asio::awaitable<void>` and uses `co_await` on the connection.
+
+```cpp
+server.addRouteWebSocket("/chat", [](geruest::WebSocketConnection& ws,
+                                     const geruest::HTTPRequest& req)
+        -> boost::asio::awaitable<void> {
+    co_await ws.send("welcome");
+
+    while (ws.isOpen()) {
+        geruest::WSMessage msg = co_await ws.recv();
+        if (msg.isClose()) break;
+        if (msg.isText()) co_await ws.send("echo: " + msg.text());
+    }
+    co_return;
+});
+```
+
+## Callback API
+
+For event-style handlers (`onOpen`, `onMessage`, `onClose`). Uses `sendNow()` for fire-and-forget replies from callbacks.
+
+```cpp
+geruest::WebSocketRoute chat;
+chat.onOpen = [](geruest::WebSocketConnection& ws, const geruest::HTTPRequest&) {
+    ws.sendNow("connected");
+};
+chat.onMessage = [](geruest::WebSocketConnection& ws, geruest::WSMessage msg) {
+    if (msg.isText()) ws.sendNow(msg.text());
+};
+chat.onClose = [](geruest::WebSocketConnection&, uint16_t code, std::string_view reason) {
+    // cleanup
+};
+server.addRouteWebSocket("/chat-cb", chat);
+```
+
+## Configuration
+
+```cpp
+server.setWebSocketMaxMessageBytes(16 * 1024 * 1024);  // default 16 MiB
+server.setWebSocketMaxFrameBytes(4 * 1024 * 1024);     // default 4 MiB
+server.setWebSocketIdleTimeout(0);                     // 0 = disabled
+server.setWebSocketPingInterval(0);                    // 0 = no server auto-ping
+server.addWebSocketSubprotocol("chat");                // optional negotiation
+```
+
+## Behavior notes
+
+- Upgrade detection runs before redirects and HTTP routes on `GET` requests with `Upgrade: websocket`.
+- After a successful `101 Switching Protocols`, the TCP connection stays in WebSocket mode until the handler returns. HTTP keep-alive does not resume on that connection.
+- Server automatically replies to client `ping` frames with `pong` (transparent to `recv()`).
+- Invalid upgrade requests on WebSocket-looking paths receive `400`; unknown WebSocket paths receive `404`.
+- Use a reverse proxy (nginx, Caddy) for WSS/TLS termination.
+
+## Client example (browser)
+
+```javascript
+const ws = new WebSocket("ws://localhost:8080/echo");
+ws.onmessage = (e) => console.log(e.data);
+ws.onopen = () => ws.send("hello");
+```

--- a/exemple/CMakeLists.txt
+++ b/exemple/CMakeLists.txt
@@ -60,6 +60,7 @@ set(GERUEST_SOURCES
     ../src/server/Socket.cpp
     ../src/server/Workers.cpp
     ../src/server/HttpSession.cpp
+    ../src/server/WebSocket.cpp
     ../src/server/Status.cpp
     ../src/auth/BasicAuth.cpp
     ../src/builders/AssetMerger.cpp

--- a/exemple/exemple.cpp
+++ b/exemple/exemple.cpp
@@ -7,11 +7,15 @@
  * @brief Example of how to use the Geruest server
  */
 
- #include <iostream>
-#include <memory>
-#include <string>
+#include <algorithm>
 #include <csignal>
 #include <filesystem>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
 #include "Geruest.hpp"
 #include "data/MethodNotAllowed.hpp"
 #if GERUEST_HAS_CURL
@@ -43,6 +47,102 @@ void signalHandler(int signum) {
 }
 
 void addRoutes(Geruest* serverToAddRoutes);
+
+namespace {
+
+constexpr size_t kChatMaxNameLen  = 32;
+constexpr size_t kChatMaxTextLen  = 2000;
+
+struct ChatRoom {
+    std::mutex                                        mu;
+    std::vector<WebSocketConnection*>                 members;
+    std::unordered_map<WebSocketConnection*, std::string> names;
+
+    static std::string trimName(std::string name) {
+        if (name.size() > kChatMaxNameLen) {
+            name.resize(kChatMaxNameLen);
+        }
+        return name;
+    }
+
+    std::string nameFor(WebSocketConnection* ws) const {
+        if (ws == nullptr) {
+            return "?";
+        }
+        const auto it = names.find(ws);
+        if (it != names.end() && !it->second.empty()) {
+            return it->second;
+        }
+        return ws->clientIp();
+    }
+
+    void broadcastLocked(std::string_view line) {
+        for (WebSocketConnection* peer : members) {
+            if (peer != nullptr && peer->isOpen()) {
+                peer->sendNow(line);
+            }
+        }
+    }
+
+    void join(WebSocketConnection& ws, const HTTPRequest& req) {
+        std::string name = trimName(req.getParam("name"));
+        if (name.empty()) {
+            name = "guest-" + ws.clientIp();
+        }
+
+        std::lock_guard<std::mutex> lock(mu);
+        names[&ws] = name;
+        members.push_back(&ws);
+        broadcastLocked("[join] " + name + " (" + std::to_string(members.size()) + " online)\n");
+    }
+
+    void leave(WebSocketConnection& ws) {
+        std::string name;
+        {
+            std::lock_guard<std::mutex> lock(mu);
+            name = nameFor(&ws);
+            members.erase(std::remove(members.begin(), members.end(), &ws), members.end());
+            names.erase(&ws);
+            if (!members.empty()) {
+                broadcastLocked("[leave] " + name + " (" + std::to_string(members.size()) + " online)\n");
+            }
+        }
+    }
+
+    void handleMessage(WebSocketConnection& ws, std::string_view text) {
+        std::string payload(text);
+        if (payload.size() > kChatMaxTextLen) {
+            payload.resize(kChatMaxTextLen);
+        }
+
+        if (payload.rfind("/nick ", 0) == 0) {
+            std::string newName = trimName(payload.substr(6));
+            if (newName.empty()) {
+                ws.sendNow("[system] usage: /nick YourName\n");
+                return;
+            }
+            std::string oldName;
+            {
+                std::lock_guard<std::mutex> lock(mu);
+                oldName = nameFor(&ws);
+                names[&ws] = newName;
+                broadcastLocked("[nick] " + oldName + " -> " + newName + "\n");
+            }
+            return;
+        }
+
+        std::string line;
+        {
+            std::lock_guard<std::mutex> lock(mu);
+            line = nameFor(&ws) + ": " + payload + "\n";
+            broadcastLocked(line);
+        }
+    }
+};
+
+ChatRoom g_chat;
+
+}  // namespace
 
 int main(int argc, char* argv[]) {
 
@@ -256,6 +356,8 @@ int main(int argc, char* argv[]) {
     std::cout << "  POST http://" << HOSTNAME << ":" << PORT << "/api/post" << std::endl;
     std::cout << "  POST http://" << HOSTNAME << ":" << PORT << "/api/send-test-email (Email)" << std::endl;
     std::cout << "  WEB  http://" << HOSTNAME << ":" << PORT << "/email-test (Email Test Page)" << std::endl;
+    std::cout << "  WEB  http://" << HOSTNAME << ":" << PORT << "/chat (WebSocket Chat)" << std::endl;
+    std::cout << "  WS   ws://" << HOSTNAME << ":" << PORT << "/chat?name=Alice" << std::endl;
     std::cout << "  Wildcard: http://" << HOSTNAME << ":" << PORT << "/api/anything" << std::endl;
     std::cout << "  Static files from: ./website/" << std::endl;
     std::cout << "\n=== Controls ===" << std::endl;
@@ -273,6 +375,36 @@ int main(int argc, char* argv[]) {
 }
 
 void addRoutes(Geruest* serverToAddRoutes) {
+    // WebSocket echo (coroutine API)
+    serverToAddRoutes->addRouteWebSocket(
+        "/echo",
+        [](WebSocketConnection& ws, const HTTPRequest&) -> boost::asio::awaitable<void> {
+            WSMessage msg = co_await ws.recv();
+            if (msg.isText()) {
+                co_await ws.send(msg.text());
+            }
+            co_return;
+        });
+
+    // WebSocket echo (callback API)
+    WebSocketRoute echoCb;
+    echoCb.onMessage = [](WebSocketConnection& ws, WSMessage msg) {
+        if (msg.isText()) {
+            ws.sendNow(msg.text());
+        }
+    };
+    serverToAddRoutes->addRouteWebSocket("/echo-cb", echoCb);
+
+    WebSocketRoute chat;
+    chat.onOpen = [](WebSocketConnection& ws, const HTTPRequest& req) { g_chat.join(ws, req); };
+    chat.onMessage = [](WebSocketConnection& ws, WSMessage msg) {
+        if (msg.isText()) {
+            g_chat.handleMessage(ws, msg.text());
+        }
+    };
+    chat.onClose = [](WebSocketConnection& ws, uint16_t, std::string_view) { g_chat.leave(ws); };
+    serverToAddRoutes->addRouteWebSocket("/chat", chat);
+
     // Example GET route
     serverToAddRoutes->addRoute("/test", [](const HTTPRequest& req) {
         HTTPResponse response("200 OK");

--- a/exemple/website/html/chat.html
+++ b/exemple/website/html/chat.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WebSocket Chat - Geruest</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #1a1a2e;
+            color: #eee;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            padding: 24px;
+        }
+        .panel {
+            width: 100%;
+            max-width: 640px;
+            background: #16213e;
+            border-radius: 12px;
+            box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+        header {
+            padding: 16px 20px;
+            background: #0f3460;
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+        header h1 { font-size: 1.1rem; flex: 1; }
+        #status { font-size: 0.85rem; color: #94a3b8; }
+        #log {
+            flex: 1;
+            min-height: 320px;
+            max-height: 50vh;
+            overflow-y: auto;
+            padding: 16px 20px;
+            font-family: ui-monospace, monospace;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+        footer {
+            display: flex;
+            gap: 8px;
+            padding: 16px 20px;
+            border-top: 1px solid #0f3460;
+        }
+        input[type="text"] {
+            flex: 1;
+            padding: 10px 12px;
+            border: 1px solid #334155;
+            border-radius: 8px;
+            background: #1e293b;
+            color: #f1f5f9;
+            font-size: 1rem;
+        }
+        button {
+            padding: 10px 16px;
+            border: none;
+            border-radius: 8px;
+            background: #e94560;
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        button:disabled { opacity: 0.5; cursor: not-allowed; }
+        .hint {
+            padding: 0 20px 12px;
+            font-size: 0.8rem;
+            color: #64748b;
+        }
+    </style>
+</head>
+<body>
+    <div class="panel">
+        <header>
+            <h1>Geruest Chat</h1>
+            <span id="status">disconnected</span>
+            <button type="button" id="connectBtn">Connect</button>
+        </header>
+        <div id="log"></div>
+        <p class="hint">Tip: send <code>/nick YourName</code> to rename. Open multiple tabs to test broadcast.</p>
+        <footer>
+            <input type="text" id="name" placeholder="Display name" maxlength="32" />
+            <input type="text" id="message" placeholder="Message…" disabled />
+            <button type="button" id="sendBtn" disabled>Send</button>
+        </footer>
+    </div>
+    <script>
+        const logEl = document.getElementById('log');
+        const statusEl = document.getElementById('status');
+        const nameEl = document.getElementById('name');
+        const msgEl = document.getElementById('message');
+        const sendBtn = document.getElementById('sendBtn');
+        const connectBtn = document.getElementById('connectBtn');
+
+        let ws = null;
+
+        function appendLine(text) {
+            logEl.textContent += text;
+            logEl.scrollTop = logEl.scrollHeight;
+        }
+
+        function setConnected(on) {
+            statusEl.textContent = on ? 'connected' : 'disconnected';
+            msgEl.disabled = !on;
+            sendBtn.disabled = !on;
+            connectBtn.textContent = on ? 'Disconnect' : 'Connect';
+            nameEl.disabled = on;
+        }
+
+        function chatUrl() {
+            const name = encodeURIComponent(nameEl.value.trim() || 'guest');
+            const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+            return `${proto}//${location.host}/chat?name=${name}`;
+        }
+
+        function connect() {
+            if (ws) {
+                ws.close();
+                return;
+            }
+            ws = new WebSocket(chatUrl());
+            ws.onopen = () => setConnected(true);
+            ws.onclose = () => {
+                setConnected(false);
+                ws = null;
+                appendLine('[system] disconnected\n');
+            };
+            ws.onerror = () => appendLine('[system] connection error\n');
+            ws.onmessage = (e) => appendLine(e.data);
+        }
+
+        function send() {
+            const text = msgEl.value.trim();
+            if (!text || !ws || ws.readyState !== WebSocket.OPEN) return;
+            ws.send(text);
+            msgEl.value = '';
+        }
+
+        connectBtn.addEventListener('click', connect);
+        sendBtn.addEventListener('click', send);
+        msgEl.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') send();
+        });
+        nameEl.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && !ws) connect();
+        });
+    </script>
+</body>
+</html>

--- a/src/Geruest.cpp
+++ b/src/Geruest.cpp
@@ -94,6 +94,41 @@ void Geruest::addRouteAsync(const std::string& path, AsyncRouteHandler routeHand
     serverData.addRouteAsync(path, std::move(routeHandler));
 }
 
+void Geruest::addRouteWebSocket(const std::string& path, WebSocketHandler handler) {
+    serverData.addWebSocketRoute(path, std::move(handler));
+    sendToLogger("Added WebSocket route: " + path);
+}
+
+void Geruest::addRouteWebSocket(const std::string& path, WebSocketRoute route) {
+    serverData.addWebSocketRoute(path, adaptWebSocketRoute(std::move(route)));
+    sendToLogger("Added WebSocket callback route: " + path);
+}
+
+void Geruest::setWebSocketMaxMessageBytes(size_t bytes) {
+    serverData.setWebSocketMaxMessageBytes(bytes);
+    sendToLogger("WebSocket max message bytes set to: " + std::to_string(bytes));
+}
+
+void Geruest::setWebSocketMaxFrameBytes(size_t bytes) {
+    serverData.setWebSocketMaxFrameBytes(bytes);
+    sendToLogger("WebSocket max frame bytes set to: " + std::to_string(bytes));
+}
+
+void Geruest::setWebSocketIdleTimeout(int seconds) {
+    serverData.setWebSocketIdleTimeout(std::chrono::seconds(seconds));
+    sendToLogger("WebSocket idle timeout set to: " + std::to_string(seconds) + "s");
+}
+
+void Geruest::setWebSocketPingInterval(int seconds) {
+    serverData.setWebSocketPingInterval(std::chrono::seconds(seconds));
+    sendToLogger("WebSocket ping interval set to: " + std::to_string(seconds) + "s");
+}
+
+void Geruest::addWebSocketSubprotocol(const std::string& name) {
+    serverData.addWebSocketSubprotocol(name);
+    sendToLogger("Added WebSocket subprotocol: " + name);
+}
+
 void Geruest::setDatabaseBackend(DatabaseBackend backend) {
     _databaseBackend = backend;
     _configFlags.databaseBackendSet = true;

--- a/src/Geruest.hpp
+++ b/src/Geruest.hpp
@@ -325,6 +325,7 @@ class Geruest {
      * When enabled, development mode:
      * - Sets log level to Debug (shows all logs including verbose information)
      * - Disables file caching (content generated in-memory only)
+     * - Disables text response cache (html/js/css rebuilt on every request)
      * - Keeps HTML/CSS/JS comments (easier debugging)
      * 
      * This is particularly useful during development when HTML, CSS, and JS files

--- a/src/Geruest.hpp
+++ b/src/Geruest.hpp
@@ -32,6 +32,7 @@
 #include "data/HTTPRequest.hpp"
 #include "data/HTTPResponse.hpp"
 #include "data/ServerData.hpp"
+#include "server/WebSocket.hpp"
 #include "database/DatabaseClient.hpp"
 #include "parser/JSONParser.hpp"
 #include "config/ConfigLoader.hpp"
@@ -64,6 +65,14 @@ class Geruest {
 
     void addRoute(const std::string& path, RouteHandler handler);
     void addRouteAsync(const std::string& path, AsyncRouteHandler handler);
+    void addRouteWebSocket(const std::string& path, WebSocketHandler handler);
+    void addRouteWebSocket(const std::string& path, WebSocketRoute route);
+
+    void setWebSocketMaxMessageBytes(size_t bytes);
+    void setWebSocketMaxFrameBytes(size_t bytes);
+    void setWebSocketIdleTimeout(int seconds);
+    void setWebSocketPingInterval(int seconds);
+    void addWebSocketSubprotocol(const std::string& name);
     void setDatabaseBackend(DatabaseBackend backend);
     void setDatabasePoolSize(size_t size);
     void setSqliteExecutorThreadCount(size_t count);

--- a/src/auth/BasicAuth.cpp
+++ b/src/auth/BasicAuth.cpp
@@ -8,56 +8,19 @@
  */
 
 #include "auth/BasicAuth.hpp"
+#include "security/Base64.hpp"
+
 #include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
 #include <sstream>
 #include <vector>
-#include <iomanip>
-#include <cstring>
-#include <cstdint>
 
 namespace geruest {
 
-// Base64 decoding lookup table
-static const std::string base64_chars = 
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    "abcdefghijklmnopqrstuvwxyz"
-    "0123456789+/";
-
 std::string BasicAuth::base64Decode(const std::string& encoded) {
-    std::string decoded;
-    std::vector<int> temp(4);
-    
-    size_t i = 0;
-    size_t len = encoded.length();
-    
-    while (i < len && encoded[i] != '=') {
-        // Collect 4 base64 characters
-        size_t j = 0;
-        while (j < 4 && i < len && encoded[i] != '=') {
-            size_t pos = base64_chars.find(encoded[i]);
-            if (pos == std::string::npos) {
-                // Invalid character, skip it
-                i++;
-                continue;
-            }
-            temp[j] = static_cast<int>(pos);
-            j++;
-            i++;
-        }
-        
-        // Decode the collected characters
-        if (j >= 2) {
-            decoded += static_cast<char>((temp[0] << 2) + ((temp[1] & 0x30) >> 4));
-        }
-        if (j >= 3) {
-            decoded += static_cast<char>(((temp[1] & 0xf) << 4) + ((temp[2] & 0x3c) >> 2));
-        }
-        if (j >= 4) {
-            decoded += static_cast<char>(((temp[2] & 0x3) << 6) + temp[3]);
-        }
-    }
-    
-    return decoded;
+    return geruest::base64Decode(std::string_view(encoded));
 }
 
 std::string BasicAuth::sha256Hash(const std::string& input) {

--- a/src/data/HTTPRequest.hpp
+++ b/src/data/HTTPRequest.hpp
@@ -125,6 +125,76 @@ class HTTPRequest {
     static std::string toLower(std::string_view str);
 };
 
+[[nodiscard]] inline bool httpConnectionHeaderHasToken(std::string_view value, std::string_view token) {
+    size_t i = 0;
+    while (i < value.size()) {
+        while (i < value.size()) {
+            const unsigned char c = static_cast<unsigned char>(value[i]);
+            if (c != ' ' && c != '\t' && c != ',') {
+                break;
+            }
+            ++i;
+        }
+        if (i >= value.size()) {
+            break;
+        }
+        size_t j = i;
+        while (j < value.size() && value[j] != ',') {
+            ++j;
+        }
+        std::string_view part = value.substr(i, j - i);
+        while (!part.empty() && std::isspace(static_cast<unsigned char>(part.front()))) {
+            part.remove_prefix(1);
+        }
+        while (!part.empty() && std::isspace(static_cast<unsigned char>(part.back()))) {
+            part.remove_suffix(1);
+        }
+        if (part.size() == token.size()) {
+            bool match = true;
+            for (size_t k = 0; k < token.size(); ++k) {
+                const unsigned char c = static_cast<unsigned char>(part[k]);
+                const unsigned char t = static_cast<unsigned char>(token[k]);
+                const unsigned char lower = (c >= 'A' && c <= 'Z') ? static_cast<unsigned char>(c + ('a' - 'A')) : c;
+                if (lower != t) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                return true;
+            }
+        }
+        i = j;
+    }
+    return false;
+}
+
+/** True when the server should not wait for another request on this connection. */
+[[nodiscard]] inline bool httpShouldCloseAfterResponse(std::string_view requestLine,
+                                                       std::string_view connectionHeader) {
+    if (!connectionHeader.empty()) {
+        if (httpConnectionHeaderHasToken(connectionHeader, "close")) {
+            return true;
+        }
+        if (httpConnectionHeaderHasToken(connectionHeader, "keep-alive")) {
+            return false;
+        }
+    }
+
+    const size_t lastSp = requestLine.rfind(' ');
+    if (lastSp == std::string_view::npos || lastSp + 1 >= requestLine.size()) {
+        return true;
+    }
+    std::string_view version = requestLine.substr(lastSp + 1);
+    while (!version.empty() && std::isspace(static_cast<unsigned char>(version.front()))) {
+        version.remove_prefix(1);
+    }
+    while (!version.empty() && std::isspace(static_cast<unsigned char>(version.back()))) {
+        version.remove_suffix(1);
+    }
+    return version == "HTTP/1.0";
+}
+
 [[nodiscard]] inline bool httpExpectIs100Continue(std::string_view value) {
     size_t i = 0;
     while (i < value.size() && std::isspace(static_cast<unsigned char>(value[i]))) {

--- a/src/data/ServerData.hpp
+++ b/src/data/ServerData.hpp
@@ -245,7 +245,79 @@ class ServerData {
             || target.rfind("//", 0) == 0;
     }
 
-    std::optional<std::pair<std::string, int>> findMatchingWildcardRedirect(const std::string& path) const {
+    std::optional<std::string> extractSupportedLanguagePrefix(const std::string& path) const {
+        if (path.size() < 3 || path[0] != '/') {
+            return std::nullopt;
+        }
+
+        const auto slashPos = path.find('/', 1);
+        const size_t langLen = (slashPos == std::string::npos) ? (path.size() - 1) : (slashPos - 1);
+        if (langLen != 2) {
+            return std::nullopt;
+        }
+
+        const char c1 = path[1];
+        const char c2 = path[2];
+        if (!std::isalpha(static_cast<unsigned char>(c1)) || !std::isalpha(static_cast<unsigned char>(c2))) {
+            return std::nullopt;
+        }
+
+        const std::string lang = path.substr(1, 2);
+        if (!isLanguageAvailable(lang)) {
+            return std::nullopt;
+        }
+
+        return lang;
+    }
+
+    bool hasSupportedLanguagePrefixInTarget(const std::string& target) const {
+        return extractSupportedLanguagePrefix(target).has_value();
+    }
+
+    std::optional<std::string> stripSupportedLanguagePrefix(const std::string& path) const {
+        const auto lang = extractSupportedLanguagePrefix(path);
+        if (!lang.has_value()) {
+            return std::nullopt;
+        }
+
+        if (path.size() == 3) {
+            return std::string("/");
+        }
+
+        return path.substr(3);
+    }
+
+    std::string normalizeRedirectTargetLanguage(const std::string& target, const std::string& requestPath) const {
+        if (!hasLanguages() || target.empty()) {
+            return target;
+        }
+
+        if (isLikelyExternalTarget(target)) {
+            return target;
+        }
+
+        if (target[0] != '/') {
+            return target;
+        }
+
+        if (hasSupportedLanguagePrefixInTarget(target)) {
+            return target;
+        }
+
+        const auto requestLang = extractSupportedLanguagePrefix(requestPath);
+        if (!requestLang.has_value()) {
+            return target;
+        }
+
+        if (target == "/") {
+            return "/" + *requestLang + "/";
+        }
+
+        return "/" + *requestLang + target;
+    }
+
+    std::optional<std::pair<std::string, int>> findMatchingWildcardRedirect(const std::string& path,
+                                                                            const std::string& requestPath) const {
         size_t bestPatternLength = 0;
         std::optional<std::pair<std::string, int>> bestMatch;
 
@@ -260,7 +332,8 @@ class ServerData {
                 continue;
             }
 
-            const std::string resolvedTarget = applyWildcardCapture(redirect.second.target, *capture);
+            const std::string capturedTarget = applyWildcardCapture(redirect.second.target, *capture);
+            const std::string resolvedTarget = normalizeRedirectTargetLanguage(capturedTarget, requestPath);
             if (!bestMatch.has_value() || pattern.size() > bestPatternLength) {
                 bestPatternLength = pattern.size();
                 bestMatch = std::make_pair(resolvedTarget, redirect.second.status);
@@ -484,11 +557,29 @@ class ServerData {
         // Priority rule 1: exact redirect first
         auto exactMatch = _redirects.find(path);
         if (exactMatch != _redirects.end()) {
-            return std::make_pair(exactMatch->second.target, exactMatch->second.status);
+            return std::make_pair(normalizeRedirectTargetLanguage(exactMatch->second.target, path),
+                                  exactMatch->second.status);
         }
 
         // Priority rule 2: wildcard redirect after exact redirect
-        return findMatchingWildcardRedirect(path);
+        auto wildcardMatch = findMatchingWildcardRedirect(path, path);
+        if (wildcardMatch.has_value()) {
+            return wildcardMatch;
+        }
+
+        // If request starts with supported language prefix, retry redirects on stripped path.
+        const auto strippedPath = stripSupportedLanguagePrefix(path);
+        if (!strippedPath.has_value()) {
+            return std::nullopt;
+        }
+
+        exactMatch = _redirects.find(*strippedPath);
+        if (exactMatch != _redirects.end()) {
+            return std::make_pair(normalizeRedirectTargetLanguage(exactMatch->second.target, path),
+                                  exactMatch->second.status);
+        }
+
+        return findMatchingWildcardRedirect(*strippedPath, path);
     }
 
     /**

--- a/src/data/ServerData.hpp
+++ b/src/data/ServerData.hpp
@@ -714,6 +714,7 @@ class ServerData {
      * When enabled:
      * - Log level is automatically set to Debug (all logs shown)
      * - Files are generated in-memory only (not saved to disk)
+     * - Text response cache disabled (html/js/css rebuilt every request)
      * - Comments are kept (easier debugging)
      * - Asset merging setting is preserved (can be enabled or disabled separately)
      * This is useful during development when HTML/CSS/JS change frequently
@@ -723,6 +724,8 @@ class ServerData {
         _devMode = true;
         setLogLevel(LogLevel::Debug);  // Show all logs
         _removeComments = false;       // Keep comments for easier debugging
+        _textResponseCacheMaxEntryBytes = 0;
+        _textResponseCacheMaxTotalBytes = 0;
         // Note: Asset merging is NOT disabled - user can control it separately
     }
 

--- a/src/data/ServerData.hpp
+++ b/src/data/ServerData.hpp
@@ -32,6 +32,7 @@
 #include "database/DatabaseClient.hpp"
 #include "../auth/BasicAuth.hpp"
 #include "parser/JSONParser.hpp"
+#include "server/WebSocketTypes.hpp"
 
 namespace geruest {
 
@@ -51,9 +52,13 @@ enum class LogLevel {
     Debug = 4
 };
 
+class WebSocketConnection;
+
 using RouteHandler = std::function<HTTPResponse(const HTTPRequest&)>;
 using AsyncResponse = boost::asio::awaitable<HTTPResponse>;
 using AsyncRouteHandler = std::function<AsyncResponse(const HTTPRequest&)>;
+using WebSocketHandler =
+    std::function<boost::asio::awaitable<void>(WebSocketConnection&, const HTTPRequest&)>;
 
 // class with the server data
 class ServerData {
@@ -67,6 +72,10 @@ class ServerData {
     std::unordered_map<std::string, RouteHandler> _wildcardRoutes;
     std::unordered_map<std::string, AsyncRouteHandler> _asyncRoutes;
     std::unordered_map<std::string, AsyncRouteHandler> _asyncWildcardRoutes;
+    std::unordered_map<std::string, WebSocketHandler> _webSocketRoutes;
+    std::unordered_map<std::string, WebSocketHandler> _webSocketWildcardRoutes;
+    WebSocketLimits _webSocketLimits{};
+    std::vector<std::string> _webSocketSubprotocols;
     std::unordered_map<std::string, RedirectRule> _redirects;
     std::unordered_map<std::string, RedirectRule> _wildcardRedirects;
     std::string _root;
@@ -405,6 +414,10 @@ class ServerData {
           _wildcardRoutes(other._wildcardRoutes),
           _asyncRoutes(other._asyncRoutes),
           _asyncWildcardRoutes(other._asyncWildcardRoutes),
+          _webSocketRoutes(other._webSocketRoutes),
+          _webSocketWildcardRoutes(other._webSocketWildcardRoutes),
+          _webSocketLimits(other._webSocketLimits),
+          _webSocketSubprotocols(other._webSocketSubprotocols),
           _redirects(other._redirects),
           _wildcardRedirects(other._wildcardRedirects),
           _root(other._root),
@@ -439,6 +452,10 @@ class ServerData {
             _wildcardRoutes = other._wildcardRoutes;
             _asyncRoutes = other._asyncRoutes;
             _asyncWildcardRoutes = other._asyncWildcardRoutes;
+            _webSocketRoutes = other._webSocketRoutes;
+            _webSocketWildcardRoutes = other._webSocketWildcardRoutes;
+            _webSocketLimits = other._webSocketLimits;
+            _webSocketSubprotocols = other._webSocketSubprotocols;
             _redirects = other._redirects;
             _wildcardRedirects = other._wildcardRedirects;
             _root = other._root;
@@ -502,6 +519,14 @@ class ServerData {
             _asyncWildcardRoutes[path] = std::move(routeHandler);
         } else {
             _asyncRoutes[path] = std::move(routeHandler);
+        }
+    }
+
+    void addWebSocketRoute(const std::string& path, WebSocketHandler routeHandler) {
+        if (path.find('*') != std::string::npos) {
+            _webSocketWildcardRoutes[path] = std::move(routeHandler);
+        } else {
+            _webSocketRoutes[path] = std::move(routeHandler);
         }
     }
 
@@ -616,6 +641,28 @@ class ServerData {
         }
         return std::nullopt;
     }
+
+    std::optional<WebSocketHandler> findMatchingWebSocketRoute(const std::string& path) const {
+        auto exactMatch = _webSocketRoutes.find(path);
+        if (exactMatch != _webSocketRoutes.end()) {
+            return exactMatch->second;
+        }
+        for (const auto& route : _webSocketWildcardRoutes) {
+            if (matchesWildcardPattern(route.first, path)) {
+                return route.second;
+            }
+        }
+        return std::nullopt;
+    }
+
+    void setWebSocketMaxMessageBytes(size_t bytes) { _webSocketLimits.maxMessageBytes = bytes; }
+    void setWebSocketMaxFrameBytes(size_t bytes) { _webSocketLimits.maxFrameBytes = bytes; }
+    void setWebSocketIdleTimeout(std::chrono::seconds seconds) { _webSocketLimits.idleTimeout = seconds; }
+    void setWebSocketPingInterval(std::chrono::seconds seconds) { _webSocketLimits.pingInterval = seconds; }
+    void addWebSocketSubprotocol(std::string name) { _webSocketSubprotocols.push_back(std::move(name)); }
+
+    const WebSocketLimits& getWebSocketLimits() const { return _webSocketLimits; }
+    const std::vector<std::string>& getWebSocketSubprotocols() const { return _webSocketSubprotocols; }
 
     const std::string& getRoot() const { return _root; }
     void setRoot(const std::string& newRoot) { _root = newRoot; }

--- a/src/email/EmailSender.cpp
+++ b/src/email/EmailSender.cpp
@@ -59,8 +59,8 @@ void EmailSender::stop() {
     activeWorkers.clear();
 }
 
-bool EmailSender::enqueueEmail(const std::string& to, const std::string& subject,
-                               const std::string& body, const std::string& clientIP) {
+bool EmailSender::enqueueEmail(const std::string& to, const std::string& subject, const std::string& body,
+                               const std::string& clientIP, const std::string& extraRFC822Headers) {
     // Check spam protection and update IP tracking atomically
     if (!checkAndUpdateSpamProtection(clientIP)) {
         _emailsRejected++;
@@ -76,7 +76,7 @@ bool EmailSender::enqueueEmail(const std::string& to, const std::string& subject
             return false;
         }
 
-        emailQueue.emplace(to, subject, body, clientIP);
+        emailQueue.emplace(to, subject, body, clientIP, extraRFC822Headers);
 
         // Create new worker thread if needed
         if (activeWorkers.size() < EMAIL_WORKER_COUNT) {
@@ -275,6 +275,16 @@ static size_t payloadSource(char* ptr, size_t size, size_t nmemb, void* userp) {
     return toCopy;
 }
 
+/** Remove accidental blank header lines so extra block cannot inject end-of-headers early. */
+static std::string collapseAccidentalHeaderBlankLines(std::string h) {
+    for (;;) {
+        const auto p = h.find("\r\n\r\n");
+        if (p == std::string::npos) break;
+        h.erase(p, 2);
+    }
+    return h;
+}
+
 bool EmailSender::sendEmail(const Email& email) {
     CURL* curl = curl_easy_init();
     if (!curl) return false;
@@ -286,7 +296,12 @@ bool EmailSender::sendEmail(const Email& email) {
     std::string from = "From: " + config.fromAddress + "\r\n";
     std::string to = "To: " + sanitizedTo + "\r\n";
     std::string subject = "Subject: " + sanitizedSubject + "\r\n";
-    std::string data = from + to + subject + "\r\n" + email.body + "\r\n";
+    std::string extra = collapseAccidentalHeaderBlankLines(email.extraRFC822Headers);
+    std::string headerBlock = from + to + subject;
+    if (!extra.empty()) {
+        headerBlock += extra;
+    }
+    std::string data = headerBlock + "\r\n" + email.body + "\r\n";
 
     struct curl_slist* recipients = nullptr;
     recipients = curl_slist_append(recipients, sanitizedTo.c_str());

--- a/src/email/EmailSender.hpp
+++ b/src/email/EmailSender.hpp
@@ -19,6 +19,7 @@
 #include <queue>
 #include <string>
 #include <thread>
+#include <utility>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -36,17 +37,20 @@ struct Email {
     std::string subject;
     std::string body;
     std::string clientIP;
+    /** Optional RFC 822 header lines after Subject (each line ends with CRLF). Example: MIME-Version + Content-Type. */
+    std::string extraRFC822Headers;
     std::chrono::steady_clock::time_point timestamp;
     int retries = 0;
 
     Email() : timestamp(std::chrono::steady_clock::now()) {}
-    
-    Email(const std::string& to_, const std::string& subject_,
-          const std::string& body_, const std::string& clientIP_)
+
+    Email(const std::string& to_, const std::string& subject_, const std::string& body_,
+          const std::string& clientIP_, std::string extraRFC822Headers_ = {})
         : to(to_),
           subject(subject_),
           body(body_),
           clientIP(clientIP_),
+          extraRFC822Headers(std::move(extraRFC822Headers_)),
           timestamp(std::chrono::steady_clock::now()),
           retries(0) {}
 };
@@ -111,13 +115,15 @@ class EmailSender {
      * @brief Queue an email for sending (producer)
      * @param to Recipient email address (will be sanitized internally)
      * @param subject Email subject (will be sanitized internally)
-     * @param body Email body (plain text or HTML)
+     * @param body Email body (plain text, HTML, or multipart payload after all RFC 822 headers)
      * @param clientIP IP address of the client requesting the email
+     * @param extraRFC822Headers Optional lines inserted after Subject, before the blank line that starts the body
+     *        (e.g. MIME-Version and Content-Type for multipart/alternative). Each line must end with CRLF.
      * @return true if email was queued, false if rejected due to spam protection
      * @note Header values (to, subject) are automatically sanitized to prevent SMTP injection
      */
-    bool enqueueEmail(const std::string& to, const std::string& subject,
-                      const std::string& body, const std::string& clientIP);
+    bool enqueueEmail(const std::string& to, const std::string& subject, const std::string& body,
+                      const std::string& clientIP, const std::string& extraRFC822Headers = {});
 
     /**
      * @brief Sanitize a string for use in SMTP headers

--- a/src/handler/Handler.cpp
+++ b/src/handler/Handler.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <boost/asio/buffer.hpp>
+#include <boost/asio/error.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/write.hpp>
@@ -26,6 +27,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -165,6 +167,40 @@ size_t findHeaderEndPos(const std::string& raw) {
     while (!s.empty() && std::isspace(static_cast<unsigned char>(s.front()))) s.remove_prefix(1);
     while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) s.remove_suffix(1);
     return s;
+}
+
+[[nodiscard]] bool isExpectedKeepAliveTeardown(const boost::system::error_code& ec, std::string_view phase) {
+    if (phase != "waiting_for_request") {
+        return false;
+    }
+    return ec == boost::asio::error::eof || ec == boost::asio::error::connection_reset ||
+           ec == boost::asio::error::broken_pipe;
+}
+
+[[nodiscard]] const char* socketReadFailureHint(const boost::system::error_code& ec, std::string_view phase,
+                                                unsigned int connectionReq) {
+    if (ec == boost::asio::error::eof) {
+        if (phase == "waiting_for_request" && connectionReq > 1) {
+            return "client closed idle keep-alive connection (usually harmless)";
+        }
+        return "client closed connection (end of stream)";
+    }
+    if (ec == boost::asio::error::connection_reset) {
+        if (phase == "waiting_for_request") {
+            return "peer reset connection while waiting for next request (often browser idle teardown)";
+        }
+        return "connection reset by peer";
+    }
+    if (ec == boost::asio::error::operation_aborted) {
+        return "read operation aborted (server shutdown or cancelled I/O)";
+    }
+    if (ec == boost::asio::error::broken_pipe) {
+        return "broken pipe (peer already gone)";
+    }
+    if (ec == boost::asio::error::not_connected) {
+        return "socket is not connected";
+    }
+    return nullptr;
 }
 
 struct HeaderPreflight {
@@ -355,7 +391,7 @@ Handler::~Handler() {
     serverData.decrementActiveHandlers();
 }
 
-boost::asio::awaitable<bool> Handler::readSocketAsync(char* bufferToUse, size_t size) {
+boost::asio::awaitable<bool> Handler::readSocketAsync(char* bufferToUse, size_t size, std::string_view phase) {
     if (size > INT_MAX) {
         sendToLoggerError("Size of buffer is too big.");
         co_return false;
@@ -365,8 +401,21 @@ boost::asio::awaitable<bool> Handler::readSocketAsync(char* bufferToUse, size_t 
         const std::size_t n = co_await clientSocket.async_read_some(
             boost::asio::buffer(bufferToUse, size), boost::asio::use_awaitable);
         bufferLength = static_cast<std::int64_t>(n);
-    } catch (const boost::system::system_error&) {
-        sendToLogger("Error reading from socket.", LogLevel::Warning);
+    } catch (const boost::system::system_error& e) {
+        if (!isExpectedKeepAliveTeardown(e.code(), phase)) {
+            std::ostringstream oss;
+            oss << "Error reading from socket";
+            if (!phase.empty()) {
+                oss << " phase=" << phase;
+            }
+            oss << " connection_req=" << messageCount;
+            oss << " socket_open=" << (clientSocket.is_open() ? "yes" : "no");
+            oss << " error=[" << e.code().category().name() << ':' << e.code().value() << "] " << e.code().message();
+            if (const char* hint = socketReadFailureHint(e.code(), phase, messageCount)) {
+                oss << " hint=" << hint;
+            }
+            sendToLogger(oss.str(), LogLevel::Warning);
+        }
         co_return false;
     }
 
@@ -376,12 +425,14 @@ boost::asio::awaitable<bool> Handler::readSocketAsync(char* bufferToUse, size_t 
     co_return true;
 }
 
-boost::asio::awaitable<bool> Handler::readSocketAsync() { co_return co_await readSocketAsync(buffer.get(), BUFFER_SIZE); }
+boost::asio::awaitable<bool> Handler::readSocketAsync(std::string_view phase) {
+    co_return co_await readSocketAsync(buffer.get(), BUFFER_SIZE, phase);
+}
 
 boost::asio::awaitable<bool> Handler::discardFromSocketAsync(size_t byteCount) {
     while (byteCount > 0) {
         const size_t chunk = std::min(byteCount, static_cast<size_t>(BUFFER_SIZE));
-        if (!co_await readSocketAsync(buffer.get(), chunk)) {
+        if (!co_await readSocketAsync(buffer.get(), chunk, "discarding_body")) {
             co_return false;
         }
         if (bufferLength <= 0) {
@@ -503,7 +554,7 @@ boost::asio::awaitable<void> Handler::runAsync() {
         pendingRequestData.clear();
 
         if (raw.empty()) {
-            if (!co_await readSocketAsync()) {
+            if (!co_await readSocketAsync("waiting_for_request")) {
                 break;
             }
             if (bufferLength <= 0) {
@@ -518,7 +569,7 @@ boost::asio::awaitable<void> Handler::runAsync() {
                 sendToLoggerError("HTTP headers exceed maximum size.");
                 co_return;
             }
-            if (!co_await readSocketAsync()) {
+            if (!co_await readSocketAsync("reading_headers")) {
                 co_return;
             }
             if (bufferLength <= 0) {
@@ -575,7 +626,7 @@ boost::asio::awaitable<void> Handler::runAsync() {
                     needTotal = chunkEnd;
                     break;
                 }
-                if (!co_await readSocketAsync()) {
+                if (!co_await readSocketAsync("reading_chunked_body")) {
                     co_return;
                 }
                 if (bufferLength <= 0) {
@@ -592,7 +643,7 @@ boost::asio::awaitable<void> Handler::runAsync() {
             }
         } else {
             while (raw.size() < needTotal) {
-                if (!co_await readSocketAsync()) {
+                if (!co_await readSocketAsync("reading_body")) {
                     co_return;
                 }
                 if (bufferLength <= 0) {
@@ -625,6 +676,10 @@ boost::asio::awaitable<void> Handler::runAsync() {
             serverData.recordLatency(_elapsedUs <= 0 ? 0u
                                      : _elapsedUs > 0xFFFFFFFFLL ? 0xFFFFFFFFu
                                                                  : static_cast<uint32_t>(_elapsedUs));
+        }
+
+        if (httpShouldCloseAfterResponse(hTTPRequest.getRawRequestLine(), hTTPRequest.getHeaderView("connection"))) {
+            break;
         }
 
         memset(buffer.get(), 0, BUFFER_SIZE);

--- a/src/handler/Handler.cpp
+++ b/src/handler/Handler.cpp
@@ -48,6 +48,7 @@
 #include "data/HTTPResponse.hpp"
 #include "data/MethodNotAllowed.hpp"
 #include "security/Security.hpp"
+#include "server/WebSocket.hpp"
 
 namespace {
 
@@ -660,6 +661,9 @@ boost::asio::awaitable<void> Handler::runAsync() {
         {
             const auto _reqStart = std::chrono::steady_clock::now();
             co_await handleRequestAsync(&hTTPRequest);
+            if (_upgraded) {
+                co_return;
+            }
             const auto _elapsedUs = std::chrono::duration_cast<std::chrono::microseconds>(
                                             std::chrono::steady_clock::now() - _reqStart)
                                         .count();
@@ -677,6 +681,79 @@ boost::asio::awaitable<void> Handler::runAsync() {
     co_return;
 }
 
+boost::asio::awaitable<bool> Handler::tryHandleWebSocketAsync(HTTPRequest* request) {
+    if (request == nullptr) {
+        co_return false;
+    }
+
+    if (request->getMethod() != "GET") {
+        co_return false;
+    }
+
+    if (!request->hasHeader("upgrade")) {
+        co_return false;
+    }
+
+    if (!isWebSocketUpgrade(*request)) {
+        HTTPResponse br = responseBadRequest(request);
+        br.serializeTo(responseScratch_);
+        co_await sendSocketAsync(responseScratch_.data(), responseScratch_.size());
+        _upgraded = true;
+        co_return true;
+    }
+
+    if (!request->getBody().empty()) {
+        HTTPResponse br = responseBadRequest(request);
+        br.serializeTo(responseScratch_);
+        co_await sendSocketAsync(responseScratch_.data(), responseScratch_.size());
+        _upgraded = true;
+        co_return true;
+    }
+
+    auto wsHandler = serverData.findMatchingWebSocketRoute(request->getPathString());
+    if (!wsHandler) {
+        co_await sendNotFoundResponseAsync(request);
+        _upgraded = true;
+        co_return true;
+    }
+
+    const std::string secKey = request->getHeader("sec-websocket-key");
+    const std::string acceptKey = computeAcceptKey(secKey);
+    const std::string subprotocol =
+        pickSubprotocol(request->getHeaderView("sec-websocket-protocol"),
+                        serverData.getWebSocketSubprotocols());
+    const std::string handshake = buildHandshakeResponse(acceptKey, subprotocol);
+    if (!co_await sendSocketAsync(handshake.c_str(), handshake.size())) {
+        _upgraded = true;
+        co_return true;
+    }
+
+    WebSocketConnection ws(clientSocket, IP, subprotocol, serverData.getWebSocketLimits());
+    bool handlerFailed = false;
+    try {
+        co_await (*wsHandler)(ws, *request);
+    } catch (const std::exception& e) {
+        handlerFailed = true;
+        serverData.record5xx();
+        sendToLoggerError(std::string("Exception in WebSocket handler: ") + e.what());
+    } catch (...) {
+        handlerFailed = true;
+        serverData.record5xx();
+        sendToLoggerError("Unknown exception in WebSocket handler");
+    }
+
+    if (ws.isOpen()) {
+        if (handlerFailed) {
+            co_await ws.close(1011, "internal error");
+        } else {
+            co_await ws.close(1000, "");
+        }
+    }
+
+    _upgraded = true;
+    co_return true;
+}
+
 boost::asio::awaitable<void> Handler::handleRequestAsync(HTTPRequest* request) {
     if (request == nullptr) {
         serverData.recordError();
@@ -685,6 +762,10 @@ boost::asio::awaitable<void> Handler::handleRequestAsync(HTTPRequest* request) {
         if (!co_await sendSocketAsync(header.c_str(), header.size())) {
             sendToLoggerError("Failed to send internal server error response");
         }
+        co_return;
+    }
+
+    if (co_await tryHandleWebSocketAsync(request)) {
         co_return;
     }
 

--- a/src/handler/Handler.cpp
+++ b/src/handler/Handler.cpp
@@ -72,11 +72,10 @@ std::atomic<uint64_t> gSendfileFallbackCount{0};
 }
 
 [[nodiscard]] std::shared_ptr<const std::string> lookupTextResponseCache(const std::string& key,
-                                                                          const std::string& contentPath,
                                                                           bool devMode,
                                                                           size_t maxEntryBytes,
                                                                           size_t maxTotalBytes) {
-    if (maxEntryBytes == 0 || maxTotalBytes == 0) {
+    if (devMode || maxEntryBytes == 0 || maxTotalBytes == 0) {
         return {};
     }
     std::lock_guard<std::mutex> lock(gTextResponseCacheMutex);
@@ -84,21 +83,12 @@ std::atomic<uint64_t> gSendfileFallbackCount{0};
     if (it == gTextResponseCache.end()) {
         return {};
     }
-    if (devMode && it->second.hasMtime) {
-        std::error_code ec;
-        const auto nowMtime = std::filesystem::last_write_time(contentPath, ec);
-        if (ec || nowMtime != it->second.mtime) {
-            gTextResponseCacheBytes -= it->second.sizeBytes;
-            gTextResponseCache.erase(it);
-            return {};
-        }
-    }
     return it->second.payload;
 }
 
 void storeTextResponseCache(const std::string& key, const std::string& contentPath, const std::string& payload,
-                            size_t maxEntryBytes, size_t maxTotalBytes) {
-    if (payload.empty() || maxEntryBytes == 0 || maxTotalBytes == 0 || payload.size() > maxEntryBytes) {
+                            bool devMode, size_t maxEntryBytes, size_t maxTotalBytes) {
+    if (devMode || payload.empty() || maxEntryBytes == 0 || maxTotalBytes == 0 || payload.size() > maxEntryBytes) {
         return;
     }
 
@@ -935,7 +925,7 @@ boost::asio::awaitable<void> Handler::sendFileAsync(const std::string& contentTy
     if (contentType == "text/html" || contentType == "text/javascript" || contentType == "text/css") {
         const std::string cacheKey = textResponseCacheKey(contentType, contentPath);
         if (const std::shared_ptr<const std::string> cached = lookupTextResponseCache(
-                cacheKey, contentPath, serverData.isDevMode(), serverData.getTextResponseCacheMaxEntryBytes(),
+                cacheKey, serverData.isDevMode(), serverData.getTextResponseCacheMaxEntryBytes(),
                 serverData.getTextResponseCacheMaxTotalBytes())) {
             if (!co_await sendSocketAsync(cached->data(), cached->size())) {
                 sendToLoggerError("Failed to send cached file: " + contentPath);
@@ -987,7 +977,8 @@ boost::asio::awaitable<void> Handler::sendFileAsync(const std::string& contentTy
         htmlResponse.setBody(contentBuilder->file());
 
         htmlResponse.serializeTo(responseScratch_);
-        storeTextResponseCache(cacheKey, contentPath, responseScratch_, serverData.getTextResponseCacheMaxEntryBytes(),
+        storeTextResponseCache(cacheKey, contentPath, responseScratch_, serverData.isDevMode(),
+                               serverData.getTextResponseCacheMaxEntryBytes(),
                                serverData.getTextResponseCacheMaxTotalBytes());
 
         if (!co_await sendSocketAsync(responseScratch_.data(), responseScratch_.size())) {

--- a/src/handler/Handler.cpp
+++ b/src/handler/Handler.cpp
@@ -690,16 +690,16 @@ boost::asio::awaitable<bool> Handler::tryHandleWebSocketAsync(HTTPRequest* reque
         co_return false;
     }
 
-    if (!request->hasHeader("upgrade")) {
-        co_return false;
-    }
-
     if (!isWebSocketUpgrade(*request)) {
-        HTTPResponse br = responseBadRequest(request);
-        br.serializeTo(responseScratch_);
-        co_await sendSocketAsync(responseScratch_.data(), responseScratch_.size());
-        _upgraded = true;
-        co_return true;
+        if (isWebSocketUpgradeIntent(*request)
+            && serverData.findMatchingWebSocketRoute(request->getPathString())) {
+            HTTPResponse br = responseBadRequest(request);
+            br.serializeTo(responseScratch_);
+            co_await sendSocketAsync(responseScratch_.data(), responseScratch_.size());
+            _upgraded = true;
+            co_return true;
+        }
+        co_return false;
     }
 
     if (!request->getBody().empty()) {

--- a/src/handler/Handler.hpp
+++ b/src/handler/Handler.hpp
@@ -51,6 +51,8 @@ class Handler {
     /** Unread bytes after the last fully parsed request (HTTP/1.1 pipelining / partial reads). */
     std::string pendingRequestData;
 
+    bool _upgraded = false;
+
     /** Reused for HTTPResponse::serializeTo and similar to reduce per-send allocations. */
     std::string responseScratch_;
 
@@ -73,6 +75,8 @@ class Handler {
     void sendToLoggerError(const std::string& message) const;
 
     boost::asio::awaitable<void> handleRequestAsync(HTTPRequest* request);
+
+    boost::asio::awaitable<bool> tryHandleWebSocketAsync(HTTPRequest* request);
 
     boost::asio::awaitable<void> sendFileAsync(const std::string& contentType, const std::string& contentPath,
                                                HTTPRequest* httpRequest);

--- a/src/handler/Handler.hpp
+++ b/src/handler/Handler.hpp
@@ -54,8 +54,8 @@ class Handler {
     /** Reused for HTTPResponse::serializeTo and similar to reduce per-send allocations. */
     std::string responseScratch_;
 
-    boost::asio::awaitable<bool> readSocketAsync();
-    boost::asio::awaitable<bool> readSocketAsync(char* bufferToUse, size_t size);
+    boost::asio::awaitable<bool> readSocketAsync(std::string_view phase = {});
+    boost::asio::awaitable<bool> readSocketAsync(char* bufferToUse, size_t size, std::string_view phase = {});
 
     boost::asio::awaitable<bool> discardFromSocketAsync(size_t byteCount);
 

--- a/src/security/Base64.hpp
+++ b/src/security/Base64.hpp
@@ -1,0 +1,91 @@
+/**
+ * @file Base64.hpp
+ * @brief RFC 4648 base64 encode/decode helpers.
+ */
+
+#ifndef GERUEST_BASE64_HPP
+#define GERUEST_BASE64_HPP
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace geruest {
+
+inline const char* base64Alphabet() {
+    return "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+           "abcdefghijklmnopqrstuvwxyz"
+           "0123456789+/";
+}
+
+inline std::string base64Encode(std::string_view input) {
+    static const char* const kAlphabet = base64Alphabet();
+    std::string out;
+    out.reserve(((input.size() + 2) / 3) * 4);
+
+    size_t i = 0;
+    while (i < input.size()) {
+        const uint32_t b0 = static_cast<uint8_t>(input[i]);
+        const uint32_t b1 = (i + 1 < input.size()) ? static_cast<uint8_t>(input[i + 1]) : 0;
+        const uint32_t b2 = (i + 2 < input.size()) ? static_cast<uint8_t>(input[i + 2]) : 0;
+        const uint32_t triple = (b0 << 16) | (b1 << 8) | b2;
+
+        out.push_back(kAlphabet[(triple >> 18) & 0x3F]);
+        out.push_back(kAlphabet[(triple >> 12) & 0x3F]);
+
+        if (i + 1 < input.size()) {
+            out.push_back(kAlphabet[(triple >> 6) & 0x3F]);
+        } else {
+            out.push_back('=');
+        }
+
+        if (i + 2 < input.size()) {
+            out.push_back(kAlphabet[triple & 0x3F]);
+        } else {
+            out.push_back('=');
+        }
+
+        i += 3;
+    }
+    return out;
+}
+
+inline std::string base64Decode(std::string_view encoded) {
+    static const std::string kAlphabet = base64Alphabet();
+    std::string              decoded;
+    std::vector<int>         temp(4);
+
+    size_t i = 0;
+    const size_t len = encoded.size();
+
+    while (i < len && encoded[i] != '=') {
+        size_t j = 0;
+        while (j < 4 && i < len && encoded[i] != '=') {
+            const size_t pos = kAlphabet.find(encoded[i]);
+            if (pos == std::string::npos) {
+                ++i;
+                continue;
+            }
+            temp[j] = static_cast<int>(pos);
+            ++j;
+            ++i;
+        }
+
+        if (j >= 2) {
+            decoded += static_cast<char>((temp[0] << 2) + ((temp[1] & 0x30) >> 4));
+        }
+        if (j >= 3) {
+            decoded += static_cast<char>(((temp[1] & 0xf) << 4) + ((temp[2] & 0x3c) >> 2));
+        }
+        if (j >= 4) {
+            decoded += static_cast<char>(((temp[2] & 0x3) << 6) + temp[3]);
+        }
+    }
+
+    return decoded;
+}
+
+}  // namespace geruest
+
+#endif  // GERUEST_BASE64_HPP

--- a/src/server/Config.cpp
+++ b/src/server/Config.cpp
@@ -116,8 +116,8 @@ void Geruest::loadConfig(const std::string& envFilePath) {
         }
     }
 
-    // TEXT_RESPONSE_CACHE_MAX_ENTRY_BYTES (0 = do not cache new entries)
-    if (!_configFlags.textResponseCacheMaxEntryBytesSet) {
+    // TEXT_RESPONSE_CACHE_MAX_ENTRY_BYTES (0 = do not cache new entries; ignored in dev mode)
+    if (!_configFlags.textResponseCacheMaxEntryBytesSet && !serverData.isDevMode()) {
         const size_t currentValue = serverData.getTextResponseCacheMaxEntryBytes();
         const size_t configValue = ConfigLoader::getSizeT("TEXT_RESPONSE_CACHE_MAX_ENTRY_BYTES", currentValue);
         if (configValue != currentValue) {
@@ -126,8 +126,8 @@ void Geruest::loadConfig(const std::string& envFilePath) {
         }
     }
 
-    // TEXT_RESPONSE_CACHE_MAX_TOTAL_BYTES (0 = do not cache new entries)
-    if (!_configFlags.textResponseCacheMaxTotalBytesSet) {
+    // TEXT_RESPONSE_CACHE_MAX_TOTAL_BYTES (0 = do not cache new entries; ignored in dev mode)
+    if (!_configFlags.textResponseCacheMaxTotalBytesSet && !serverData.isDevMode()) {
         const size_t currentValue = serverData.getTextResponseCacheMaxTotalBytes();
         const size_t configValue = ConfigLoader::getSizeT("TEXT_RESPONSE_CACHE_MAX_TOTAL_BYTES", currentValue);
         if (configValue != currentValue) {

--- a/src/server/Socket.cpp
+++ b/src/server/Socket.cpp
@@ -30,8 +30,8 @@ constexpr const char* kOverloadedResponse =
 
 void Geruest::statusPersistenceLoop() {
     while (running.load(std::memory_order_relaxed)) {
-        for (int i = 0; i < 3600 && running.load(std::memory_order_relaxed); ++i) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+        for (int i = 0; i < 36000 && running.load(std::memory_order_relaxed); ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
         if (!running.load(std::memory_order_relaxed)) {
             break;

--- a/src/server/WebSocket.cpp
+++ b/src/server/WebSocket.cpp
@@ -1,0 +1,644 @@
+/**
+ * @file server/WebSocket.cpp
+ */
+
+#include "WebSocket.hpp"
+
+#include "security/Base64.hpp"
+
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/write.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstring>
+#include <stdexcept>
+
+namespace geruest {
+namespace {
+
+constexpr char kWebSocketGuid[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+[[nodiscard]] inline unsigned char asciiLower(unsigned char c) noexcept {
+    return (c >= 'A' && c <= 'Z') ? static_cast<unsigned char>(c + ('a' - 'A')) : c;
+}
+
+[[nodiscard]] bool iequalsAscii(std::string_view a, std::string_view b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (asciiLower(static_cast<unsigned char>(a[i])) !=
+            asciiLower(static_cast<unsigned char>(b[i]))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::string_view trimSv(std::string_view s) {
+    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.front()))) {
+        s.remove_prefix(1);
+    }
+    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) {
+        s.remove_suffix(1);
+    }
+    return s;
+}
+
+[[nodiscard]] bool headerContainsToken(std::string_view value, std::string_view token) {
+    value = trimSv(value);
+    size_t i = 0;
+    while (i < value.size()) {
+        while (i < value.size() && (value[i] == ' ' || value[i] == '\t' || value[i] == ',')) {
+            ++i;
+        }
+        size_t j = i;
+        while (j < value.size() && value[j] != ',') {
+            ++j;
+        }
+        if (iequalsAscii(trimSv(value.substr(i, j - i)), token)) {
+            return true;
+        }
+        i = j + 1;
+    }
+    return false;
+}
+
+[[nodiscard]] bool isControlOpcode(WSOpcode op) {
+    const uint8_t v = static_cast<uint8_t>(op);
+    return v >= 0x8 && v <= 0xF;
+}
+
+void appendUint16BE(std::vector<uint8_t>& out, uint16_t v) {
+    out.push_back(static_cast<uint8_t>((v >> 8) & 0xFF));
+    out.push_back(static_cast<uint8_t>(v & 0xFF));
+}
+
+void appendUint64BE(std::vector<uint8_t>& out, uint64_t v) {
+    for (int shift = 56; shift >= 0; shift -= 8) {
+        out.push_back(static_cast<uint8_t>((v >> shift) & 0xFF));
+    }
+}
+
+void unmaskPayload(std::vector<uint8_t>& payload, const uint8_t mask[4]) {
+    for (size_t i = 0; i < payload.size(); ++i) {
+        payload[i] ^= mask[i % 4];
+    }
+}
+
+}  // namespace
+
+namespace websocket_codec {
+
+std::string sha1Hash(std::string_view input) {
+    uint32_t h0 = 0x67452301;
+    uint32_t h1 = 0xEFCDAB89;
+    uint32_t h2 = 0x98BADCFE;
+    uint32_t h3 = 0x10325476;
+    uint32_t h4 = 0xC3D2E1F0;
+
+    std::vector<uint8_t> msg(input.begin(), input.end());
+    const uint64_t       bitLen = static_cast<uint64_t>(msg.size()) * 8ULL;
+    msg.push_back(0x80);
+    while ((msg.size() % 64) != 56) {
+        msg.push_back(0x00);
+    }
+    for (int i = 7; i >= 0; --i) {
+        msg.push_back(static_cast<uint8_t>((bitLen >> (i * 8)) & 0xFF));
+    }
+
+    for (size_t chunk = 0; chunk < msg.size(); chunk += 64) {
+        uint32_t w[80]{};
+        for (int i = 0; i < 16; ++i) {
+            w[i] = (static_cast<uint32_t>(msg[chunk + i * 4]) << 24) |
+                   (static_cast<uint32_t>(msg[chunk + i * 4 + 1]) << 16) |
+                   (static_cast<uint32_t>(msg[chunk + i * 4 + 2]) << 8) |
+                   static_cast<uint32_t>(msg[chunk + i * 4 + 3]);
+        }
+        for (int i = 16; i < 80; ++i) {
+            w[i] = ((w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]) << 1) |
+                   ((w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]) >> 31);
+        }
+
+        uint32_t a = h0;
+        uint32_t b = h1;
+        uint32_t c = h2;
+        uint32_t d = h3;
+        uint32_t e = h4;
+
+        for (int i = 0; i < 80; ++i) {
+            uint32_t f = 0;
+            uint32_t k = 0;
+            if (i < 20) {
+                f = (b & c) | ((~b) & d);
+                k = 0x5A827999;
+            } else if (i < 40) {
+                f = b ^ c ^ d;
+                k = 0x6ED9EBA1;
+            } else if (i < 60) {
+                f = (b & c) | (b & d) | (c & d);
+                k = 0x8F1BBCDC;
+            } else {
+                f = b ^ c ^ d;
+                k = 0xCA62C1D6;
+            }
+            const uint32_t temp =
+                ((a << 5) | (a >> 27)) + f + e + k + w[static_cast<size_t>(i)];
+            e = d;
+            d = c;
+            c = (b << 30) | (b >> 2);
+            b = a;
+            a = temp;
+        }
+
+        h0 += a;
+        h1 += b;
+        h2 += c;
+        h3 += d;
+        h4 += e;
+    }
+
+    std::string digest(20, '\0');
+    const uint32_t hs[5] = {h0, h1, h2, h3, h4};
+    for (int i = 0; i < 5; ++i) {
+        digest[static_cast<size_t>(i * 4)]     = static_cast<char>((hs[i] >> 24) & 0xFF);
+        digest[static_cast<size_t>(i * 4 + 1)] = static_cast<char>((hs[i] >> 16) & 0xFF);
+        digest[static_cast<size_t>(i * 4 + 2)] = static_cast<char>((hs[i] >> 8) & 0xFF);
+        digest[static_cast<size_t>(i * 4 + 3)] = static_cast<char>(hs[i] & 0xFF);
+    }
+    return digest;
+}
+
+std::vector<uint8_t> encodeServerFrame(WSOpcode opcode, std::span<const uint8_t> payload, bool fin) {
+    std::vector<uint8_t> frame;
+    frame.reserve(14 + payload.size());
+    uint8_t b0 = static_cast<uint8_t>(opcode) & 0x0F;
+    if (fin) {
+        b0 |= 0x80;
+    }
+    frame.push_back(b0);
+
+    const size_t len = payload.size();
+    if (len < 126) {
+        frame.push_back(static_cast<uint8_t>(len));
+    } else if (len <= 0xFFFF) {
+        frame.push_back(126);
+        appendUint16BE(frame, static_cast<uint16_t>(len));
+    } else {
+        frame.push_back(127);
+        appendUint64BE(frame, len);
+    }
+    frame.insert(frame.end(), payload.begin(), payload.end());
+    return frame;
+}
+
+WSMessage decodeClientFrame(std::span<const uint8_t> bytes, const WebSocketLimits& limits,
+                            std::span<const uint8_t>* remainder) {
+    if (remainder) {
+        *remainder = {};
+    }
+    if (bytes.size() < 2) {
+        throw std::runtime_error("incomplete websocket frame");
+    }
+
+    const bool fin  = (bytes[0] & 0x80) != 0;
+    const auto op   = static_cast<WSOpcode>(bytes[0] & 0x0F);
+    const bool mask = (bytes[1] & 0x80) != 0;
+    uint64_t     payloadLen = bytes[1] & 0x7F;
+    size_t       headerLen  = 2;
+
+    if (!mask) {
+        throw std::runtime_error("client frame must be masked");
+    }
+
+    if (payloadLen == 126) {
+        if (bytes.size() < 4) {
+            throw std::runtime_error("incomplete extended length");
+        }
+        payloadLen = (static_cast<uint64_t>(bytes[2]) << 8) | bytes[3];
+        headerLen = 4;
+    } else if (payloadLen == 127) {
+        if (bytes.size() < 10) {
+            throw std::runtime_error("incomplete extended length");
+        }
+        payloadLen = 0;
+        for (int i = 0; i < 8; ++i) {
+            payloadLen = (payloadLen << 8) | bytes[2 + static_cast<size_t>(i)];
+        }
+        headerLen = 10;
+    }
+
+    if (payloadLen > limits.maxFrameBytes) {
+        throw std::runtime_error("frame too large");
+    }
+
+    const size_t total = headerLen + 4 + static_cast<size_t>(payloadLen);
+    if (bytes.size() < total) {
+        throw std::runtime_error("incomplete websocket frame");
+    }
+
+    uint8_t maskKey[4];
+    std::memcpy(maskKey, bytes.data() + headerLen, 4);
+    std::vector<uint8_t> payload(bytes.begin() + static_cast<std::ptrdiff_t>(headerLen + 4),
+                                 bytes.begin() + static_cast<std::ptrdiff_t>(total));
+    unmaskPayload(payload, maskKey);
+
+    if (remainder) {
+        *remainder = bytes.subspan(total);
+    }
+
+    if (isControlOpcode(op) && !fin) {
+        throw std::runtime_error("fragmented control frame");
+    }
+    if (isControlOpcode(op) && payload.size() > 125) {
+        throw std::runtime_error("control frame too large");
+    }
+
+    if (op == WSOpcode::Close) {
+        uint16_t code = 1005;
+        std::string reason;
+        if (payload.size() >= 2) {
+            code = static_cast<uint16_t>((payload[0] << 8) | payload[1]);
+            if (payload.size() > 2) {
+                reason.assign(payload.begin() + 2, payload.end());
+            }
+        }
+        return WSMessage::makeClose(code, reason);
+    }
+
+    if (op == WSOpcode::Text) {
+        return WSMessage::makeText(
+            std::string_view(reinterpret_cast<const char*>(payload.data()), payload.size()));
+    }
+    if (op == WSOpcode::Binary) {
+        return WSMessage::makeBinary(payload);
+    }
+    if (op == WSOpcode::Ping) {
+        return WSMessage::makePing(std::move(payload));
+    }
+    if (op == WSOpcode::Pong) {
+        return WSMessage::makePong(std::move(payload));
+    }
+    (void)fin;
+    return WSMessage::makeBinary(payload);
+}
+
+}  // namespace websocket_codec
+
+WSMessage WSMessage::makeText(std::string_view text) {
+    WSMessage m;
+    m._opcode = WSOpcode::Text;
+    m._payload.assign(reinterpret_cast<const uint8_t*>(text.data()),
+                      reinterpret_cast<const uint8_t*>(text.data() + text.size()));
+    return m;
+}
+
+WSMessage WSMessage::makeBinary(std::span<const uint8_t> data) {
+    WSMessage m;
+    m._opcode = WSOpcode::Binary;
+    m._payload.assign(data.begin(), data.end());
+    return m;
+}
+
+WSMessage WSMessage::makeClose(uint16_t code, std::string_view reason) {
+    WSMessage m;
+    m._opcode = WSOpcode::Close;
+    m._closeCode = code;
+    m._closeReason.assign(reason);
+    m._payload.reserve(2 + reason.size());
+    appendUint16BE(m._payload, code);
+    m._payload.insert(m._payload.end(), reason.begin(), reason.end());
+    return m;
+}
+
+WSMessage WSMessage::makePing(std::vector<uint8_t> payload) {
+    WSMessage m;
+    m._opcode = WSOpcode::Ping;
+    m._payload = std::move(payload);
+    return m;
+}
+
+WSMessage WSMessage::makePong(std::vector<uint8_t> payload) {
+    WSMessage m;
+    m._opcode = WSOpcode::Pong;
+    m._payload = std::move(payload);
+    return m;
+}
+
+bool isWebSocketUpgrade(const HTTPRequest& req) {
+    if (req.getMethod() != "GET") {
+        return false;
+    }
+    if (!headerContainsToken(req.getHeaderView("upgrade"), "websocket")) {
+        return false;
+    }
+    if (!headerContainsToken(req.getHeaderView("connection"), "upgrade")) {
+        return false;
+    }
+    if (!iequalsAscii(trimSv(req.getHeaderView("sec-websocket-version")), "13")) {
+        return false;
+    }
+    if (trimSv(req.getHeaderView("sec-websocket-key")).empty()) {
+        return false;
+    }
+    return true;
+}
+
+std::string computeAcceptKey(std::string_view secKey) {
+    std::string combined;
+    combined.reserve(secKey.size() + sizeof(kWebSocketGuid) - 1);
+    combined.append(secKey);
+    combined.append(kWebSocketGuid);
+    return base64Encode(websocket_codec::sha1Hash(combined));
+}
+
+std::string buildHandshakeResponse(std::string_view acceptKey, std::string_view subprotocol) {
+    std::string out = "HTTP/1.1 101 Switching Protocols\r\n"
+                      "Upgrade: websocket\r\n"
+                      "Connection: Upgrade\r\n"
+                      "Sec-WebSocket-Accept: ";
+    out.append(acceptKey);
+    out.append("\r\n");
+    if (!subprotocol.empty()) {
+        out.append("Sec-WebSocket-Protocol: ");
+        out.append(subprotocol);
+        out.append("\r\n");
+    }
+    out.append("\r\n");
+    return out;
+}
+
+std::string pickSubprotocol(std::string_view clientHeader, const std::vector<std::string>& serverOffered) {
+    if (clientHeader.empty() || serverOffered.empty()) {
+        return {};
+    }
+    size_t i = 0;
+    while (i < clientHeader.size()) {
+        while (i < clientHeader.size() &&
+               (clientHeader[i] == ' ' || clientHeader[i] == '\t' || clientHeader[i] == ',')) {
+            ++i;
+        }
+        size_t j = i;
+        while (j < clientHeader.size() && clientHeader[j] != ',') {
+            ++j;
+        }
+        const std::string_view token = trimSv(clientHeader.substr(i, j - i));
+        for (const auto& offered : serverOffered) {
+            if (iequalsAscii(token, offered)) {
+                return offered;
+            }
+        }
+        i = j + 1;
+    }
+    return {};
+}
+
+WebSocketConnection::WebSocketConnection(tcp_socket& sock, std::string clientIp,
+                                         std::string selectedSubprotocol, WebSocketLimits limits)
+    : _socket(sock)
+    , _strand(boost::asio::make_strand(sock.get_executor()))
+    , _clientIp(std::move(clientIp))
+    , _selectedSubprotocol(std::move(selectedSubprotocol))
+    , _limits(std::move(limits)) {}
+
+void WebSocketConnection::markClosed(uint16_t code, std::string_view reason) {
+    _open = false;
+    _closeCode = code;
+    _closeReason.assign(reason);
+}
+
+boost::asio::awaitable<void> WebSocketConnection::protocolError(uint16_t code, std::string_view reason) {
+    markClosed(code, reason);
+    try {
+        co_await writeFrame(WSOpcode::Close, WSMessage::makeClose(code, reason).data());
+    } catch (...) {
+    }
+    co_return;
+}
+
+boost::asio::awaitable<void> WebSocketConnection::writeRawFrame(std::vector<uint8_t> frame) {
+    if (!_open) {
+        co_return;
+    }
+    try {
+        co_await boost::asio::async_write(_socket, boost::asio::buffer(frame), boost::asio::use_awaitable);
+    } catch (...) {
+        markClosed(1011, "write failed");
+        throw;
+    }
+    co_return;
+}
+
+boost::asio::awaitable<void> WebSocketConnection::writeFrame(WSOpcode op, std::span<const uint8_t> payload,
+                                                             bool fin) {
+    co_await writeRawFrame(websocket_codec::encodeServerFrame(op, payload, fin));
+    co_return;
+}
+
+boost::asio::awaitable<void> WebSocketConnection::send(std::string_view text) {
+    const auto* begin = reinterpret_cast<const uint8_t*>(text.data());
+    co_await writeFrame(WSOpcode::Text, std::span<const uint8_t>(begin, text.size()));
+    co_return;
+}
+
+boost::asio::awaitable<void> WebSocketConnection::sendBinary(std::span<const uint8_t> data) {
+    co_await writeFrame(WSOpcode::Binary, data);
+    co_return;
+}
+
+boost::asio::awaitable<void> WebSocketConnection::ping(std::span<const uint8_t> payload) {
+    co_await writeFrame(WSOpcode::Ping, payload);
+    co_return;
+}
+
+boost::asio::awaitable<void> WebSocketConnection::pong(std::span<const uint8_t> payload) {
+    co_await writeFrame(WSOpcode::Pong, payload);
+    co_return;
+}
+
+boost::asio::awaitable<void> WebSocketConnection::close(uint16_t code, std::string_view reason) {
+    if (!_open) {
+        co_return;
+    }
+    markClosed(code, reason);
+    co_await writeFrame(WSOpcode::Close, WSMessage::makeClose(code, reason).data());
+    co_return;
+}
+
+void WebSocketConnection::sendNow(std::string_view text) {
+    const auto* begin = reinterpret_cast<const uint8_t*>(text.data());
+    auto        frame = websocket_codec::encodeServerFrame(WSOpcode::Text,
+                                                    std::span<const uint8_t>(begin, text.size()));
+    boost::asio::co_spawn(
+        _strand,
+        [this, frame = std::move(frame)]() mutable -> boost::asio::awaitable<void> {
+            try {
+                co_await writeRawFrame(std::move(frame));
+            } catch (...) {
+                markClosed(1011, "send failed");
+            }
+            co_return;
+        },
+        boost::asio::detached);
+}
+
+void WebSocketConnection::sendBinaryNow(std::span<const uint8_t> data) {
+    auto frame = websocket_codec::encodeServerFrame(WSOpcode::Binary, data);
+    boost::asio::co_spawn(
+        _strand,
+        [this, frame = std::move(frame)]() mutable -> boost::asio::awaitable<void> {
+            try {
+                co_await writeRawFrame(std::move(frame));
+            } catch (...) {
+                markClosed(1011, "send failed");
+            }
+            co_return;
+        },
+        boost::asio::detached);
+}
+
+boost::asio::awaitable<WSMessage> WebSocketConnection::readMessage() {
+    std::vector<uint8_t> accumulator;
+    WSOpcode             messageOpcode = WSOpcode::Continuation;
+    bool                 started       = false;
+
+    while (_open) {
+        uint8_t header[2];
+        co_await boost::asio::async_read(_socket, boost::asio::buffer(header, 2), boost::asio::use_awaitable);
+
+        const bool fin  = (header[0] & 0x80) != 0;
+        const auto op   = static_cast<WSOpcode>(header[0] & 0x0F);
+        const bool mask = (header[1] & 0x80) != 0;
+        uint64_t     payloadLen = header[1] & 0x7F;
+
+        if (!mask) {
+            co_await protocolError(1002, "unmasked client frame");
+            co_return WSMessage::makeClose(_closeCode, _closeReason);
+        }
+
+        if (payloadLen == 126) {
+            uint8_t ext[2];
+            co_await boost::asio::async_read(_socket, boost::asio::buffer(ext, 2), boost::asio::use_awaitable);
+            payloadLen = (static_cast<uint64_t>(ext[0]) << 8) | ext[1];
+        } else if (payloadLen == 127) {
+            uint8_t ext[8];
+            co_await boost::asio::async_read(_socket, boost::asio::buffer(ext, 8), boost::asio::use_awaitable);
+            payloadLen = 0;
+            for (int i = 0; i < 8; ++i) {
+                payloadLen = (payloadLen << 8) | ext[static_cast<size_t>(i)];
+            }
+        }
+
+        if (payloadLen > _limits.maxFrameBytes) {
+            co_await protocolError(1009, "frame too large");
+            co_return WSMessage::makeClose(_closeCode, _closeReason);
+        }
+
+        uint8_t maskKey[4];
+        co_await boost::asio::async_read(_socket, boost::asio::buffer(maskKey, 4), boost::asio::use_awaitable);
+
+        std::vector<uint8_t> payload(static_cast<size_t>(payloadLen));
+        if (payloadLen > 0) {
+            co_await boost::asio::async_read(_socket, boost::asio::buffer(payload), boost::asio::use_awaitable);
+            unmaskPayload(payload, maskKey);
+        }
+
+        if (isControlOpcode(op) && !fin) {
+            co_await protocolError(1002, "fragmented control");
+            co_return WSMessage::makeClose(_closeCode, _closeReason);
+        }
+        if (isControlOpcode(op) && payload.size() > 125) {
+            co_await protocolError(1002, "control frame too large");
+            co_return WSMessage::makeClose(_closeCode, _closeReason);
+        }
+
+        if (op == WSOpcode::Ping) {
+            co_await writeFrame(WSOpcode::Pong, payload);
+            continue;
+        }
+        if (op == WSOpcode::Pong) {
+            continue;
+        }
+        if (op == WSOpcode::Close) {
+            uint16_t code = 1005;
+            std::string reason;
+            if (payload.size() >= 2) {
+                code = static_cast<uint16_t>((payload[0] << 8) | payload[1]);
+                if (payload.size() > 2) {
+                    reason.assign(payload.begin() + 2, payload.end());
+                }
+            }
+            markClosed(code, reason);
+            co_await writeFrame(WSOpcode::Close, WSMessage::makeClose(code, reason).data());
+            co_return WSMessage::makeClose(code, reason);
+        }
+
+        if (op != WSOpcode::Continuation) {
+            messageOpcode = op;
+            started = true;
+            accumulator = std::move(payload);
+        } else if (started) {
+            if (accumulator.size() + payload.size() > _limits.maxMessageBytes) {
+                co_await protocolError(1009, "message too large");
+                co_return WSMessage::makeClose(_closeCode, _closeReason);
+            }
+            accumulator.insert(accumulator.end(), payload.begin(), payload.end());
+        } else {
+            co_await protocolError(1002, "unexpected continuation");
+            co_return WSMessage::makeClose(_closeCode, _closeReason);
+        }
+
+        if (fin && started) {
+            if (messageOpcode == WSOpcode::Text) {
+                co_return WSMessage::makeText(std::string_view(
+                    reinterpret_cast<const char*>(accumulator.data()), accumulator.size()));
+            }
+            co_return WSMessage::makeBinary(accumulator);
+        }
+    }
+
+    co_return WSMessage::makeClose(_closeCode, _closeReason);
+}
+
+boost::asio::awaitable<WSMessage> WebSocketConnection::recv() {
+    co_return co_await readMessage();
+}
+
+WebSocketHandler adaptWebSocketRoute(WebSocketRoute route) {
+    return [route = std::move(route)](WebSocketConnection& ws,
+                                      const HTTPRequest&   req) -> boost::asio::awaitable<void> {
+        uint16_t    closeCode = 1000;
+        std::string closeReason;
+        try {
+            if (route.onOpen) {
+                route.onOpen(ws, req);
+            }
+            while (ws.isOpen()) {
+                WSMessage msg = co_await ws.recv();
+                if (msg.isClose()) {
+                    closeCode = msg.closeCode();
+                    closeReason.assign(msg.closeReason());
+                    break;
+                }
+                if (route.onMessage) {
+                    route.onMessage(ws, std::move(msg));
+                }
+            }
+        } catch (...) {
+            closeCode = ws.closeCode() != 1005 ? ws.closeCode() : static_cast<uint16_t>(1011);
+            closeReason = ws.closeReason().empty() ? "internal error" : std::string(ws.closeReason());
+        }
+
+        if (route.onClose) {
+            route.onClose(ws, closeCode, closeReason);
+        }
+        co_return;
+    };
+}
+
+}  // namespace geruest

--- a/src/server/WebSocket.cpp
+++ b/src/server/WebSocket.cpp
@@ -79,12 +79,6 @@ void appendUint16BE(std::vector<uint8_t>& out, uint16_t v) {
     out.push_back(static_cast<uint8_t>(v & 0xFF));
 }
 
-void appendUint64BE(std::vector<uint8_t>& out, uint64_t v) {
-    for (int shift = 56; shift >= 0; shift -= 8) {
-        out.push_back(static_cast<uint8_t>((v >> shift) & 0xFF));
-    }
-}
-
 void unmaskPayload(std::vector<uint8_t>& payload, const uint8_t mask[4]) {
     for (size_t i = 0; i < payload.size(); ++i) {
         payload[i] ^= mask[i % 4];
@@ -175,25 +169,40 @@ std::string sha1Hash(std::string_view input) {
 }
 
 std::vector<uint8_t> encodeServerFrame(WSOpcode opcode, std::span<const uint8_t> payload, bool fin) {
-    std::vector<uint8_t> frame;
-    frame.reserve(14 + payload.size());
+    const size_t len = payload.size();
+    size_t         headerSize = 2;
+    if (len >= 126 && len <= 0xFFFF) {
+        headerSize = 4;
+    } else if (len > 0xFFFF) {
+        headerSize = 10;
+    }
+
+    std::vector<uint8_t> frame(headerSize + len);
+    size_t               pos = 0;
+
     uint8_t b0 = static_cast<uint8_t>(opcode) & 0x0F;
     if (fin) {
         b0 |= 0x80;
     }
-    frame.push_back(b0);
+    frame[pos++] = b0;
 
-    const size_t len = payload.size();
     if (len < 126) {
-        frame.push_back(static_cast<uint8_t>(len));
+        frame[pos++] = static_cast<uint8_t>(len);
     } else if (len <= 0xFFFF) {
-        frame.push_back(126);
-        appendUint16BE(frame, static_cast<uint16_t>(len));
+        const uint16_t len16 = static_cast<uint16_t>(len);
+        frame[pos++] = 126;
+        frame[pos++] = static_cast<uint8_t>((len16 >> 8) & 0xFF);
+        frame[pos++] = static_cast<uint8_t>(len16 & 0xFF);
     } else {
-        frame.push_back(127);
-        appendUint64BE(frame, len);
+        frame[pos++] = 127;
+        for (int shift = 56; shift >= 0; shift -= 8) {
+            frame[pos++] = static_cast<uint8_t>((len >> shift) & 0xFF);
+        }
     }
-    frame.insert(frame.end(), payload.begin(), payload.end());
+
+    if (len > 0) {
+        std::memcpy(frame.data() + pos, payload.data(), len);
+    }
     return frame;
 }
 

--- a/src/server/WebSocket.cpp
+++ b/src/server/WebSocket.cpp
@@ -330,6 +330,10 @@ WSMessage WSMessage::makePong(std::vector<uint8_t> payload) {
     return m;
 }
 
+bool isWebSocketUpgradeIntent(const HTTPRequest& req) {
+    return req.getMethod() == "GET" && headerContainsToken(req.getHeaderView("upgrade"), "websocket");
+}
+
 bool isWebSocketUpgrade(const HTTPRequest& req) {
     if (req.getMethod() != "GET") {
         return false;
@@ -398,26 +402,54 @@ std::string pickSubprotocol(std::string_view clientHeader, const std::vector<std
     return {};
 }
 
+WebSocketConnection::AsyncWriteState::AsyncWriteState(tcp_socket& sock)
+    : socket(sock), strand(boost::asio::make_strand(sock.get_executor())) {}
+
+boost::asio::awaitable<void> WebSocketConnection::AsyncWriteState::sendFrame(std::vector<uint8_t> frame) {
+    if (!writesEnabled.load(std::memory_order_relaxed)) {
+        co_return;
+    }
+    try {
+        co_await boost::asio::async_write(socket, boost::asio::buffer(frame), boost::asio::use_awaitable);
+    } catch (...) {
+        writesEnabled.store(false, std::memory_order_relaxed);
+    }
+    co_return;
+}
+
 WebSocketConnection::WebSocketConnection(tcp_socket& sock, std::string clientIp,
                                          std::string selectedSubprotocol, WebSocketLimits limits)
     : _socket(sock)
     , _strand(boost::asio::make_strand(sock.get_executor()))
+    , _asyncWrite(std::make_shared<AsyncWriteState>(sock))
     , _clientIp(std::move(clientIp))
     , _selectedSubprotocol(std::move(selectedSubprotocol))
     , _limits(std::move(limits)) {}
 
 void WebSocketConnection::markClosed(uint16_t code, std::string_view reason) {
     _open = false;
+    if (_asyncWrite) {
+        _asyncWrite->writesEnabled.store(false, std::memory_order_relaxed);
+    }
     _closeCode = code;
     _closeReason.assign(reason);
 }
 
-boost::asio::awaitable<void> WebSocketConnection::protocolError(uint16_t code, std::string_view reason) {
-    markClosed(code, reason);
+boost::asio::awaitable<void> WebSocketConnection::writeCloseFrame(uint16_t code, std::string_view reason) {
     try {
-        co_await writeFrame(WSOpcode::Close, WSMessage::makeClose(code, reason).data());
+        co_await boost::asio::async_write(
+            _socket,
+            boost::asio::buffer(websocket_codec::encodeServerFrame(
+                WSOpcode::Close, WSMessage::makeClose(code, reason).data())),
+            boost::asio::use_awaitable);
     } catch (...) {
     }
+    co_return;
+}
+
+boost::asio::awaitable<void> WebSocketConnection::protocolError(uint16_t code, std::string_view reason) {
+    co_await writeCloseFrame(code, reason);
+    markClosed(code, reason);
     co_return;
 }
 
@@ -465,8 +497,8 @@ boost::asio::awaitable<void> WebSocketConnection::close(uint16_t code, std::stri
     if (!_open) {
         co_return;
     }
+    co_await writeCloseFrame(code, reason);
     markClosed(code, reason);
-    co_await writeFrame(WSOpcode::Close, WSMessage::makeClose(code, reason).data());
     co_return;
 }
 
@@ -474,29 +506,29 @@ void WebSocketConnection::sendNow(std::string_view text) {
     const auto* begin = reinterpret_cast<const uint8_t*>(text.data());
     auto        frame = websocket_codec::encodeServerFrame(WSOpcode::Text,
                                                     std::span<const uint8_t>(begin, text.size()));
+    const std::shared_ptr<AsyncWriteState> state = _asyncWrite;
+    if (!state) {
+        return;
+    }
     boost::asio::co_spawn(
-        _strand,
-        [this, frame = std::move(frame)]() mutable -> boost::asio::awaitable<void> {
-            try {
-                co_await writeRawFrame(std::move(frame));
-            } catch (...) {
-                markClosed(1011, "send failed");
-            }
+        state->strand,
+        [state, frame = std::move(frame)]() mutable -> boost::asio::awaitable<void> {
+            co_await state->sendFrame(std::move(frame));
             co_return;
         },
         boost::asio::detached);
 }
 
 void WebSocketConnection::sendBinaryNow(std::span<const uint8_t> data) {
-    auto frame = websocket_codec::encodeServerFrame(WSOpcode::Binary, data);
+    auto                                   frame = websocket_codec::encodeServerFrame(WSOpcode::Binary, data);
+    const std::shared_ptr<AsyncWriteState> state   = _asyncWrite;
+    if (!state) {
+        return;
+    }
     boost::asio::co_spawn(
-        _strand,
-        [this, frame = std::move(frame)]() mutable -> boost::asio::awaitable<void> {
-            try {
-                co_await writeRawFrame(std::move(frame));
-            } catch (...) {
-                markClosed(1011, "send failed");
-            }
+        state->strand,
+        [state, frame = std::move(frame)]() mutable -> boost::asio::awaitable<void> {
+            co_await state->sendFrame(std::move(frame));
             co_return;
         },
         boost::asio::detached);
@@ -573,8 +605,8 @@ boost::asio::awaitable<WSMessage> WebSocketConnection::readMessage() {
                     reason.assign(payload.begin() + 2, payload.end());
                 }
             }
+            co_await writeCloseFrame(code, reason);
             markClosed(code, reason);
-            co_await writeFrame(WSOpcode::Close, WSMessage::makeClose(code, reason).data());
             co_return WSMessage::makeClose(code, reason);
         }
 

--- a/src/server/WebSocket.cpp
+++ b/src/server/WebSocket.cpp
@@ -411,17 +411,96 @@ std::string pickSubprotocol(std::string_view clientHeader, const std::vector<std
     return {};
 }
 
-WebSocketConnection::AsyncWriteState::AsyncWriteState(tcp_socket& sock)
-    : socket(sock), strand(boost::asio::make_strand(sock.get_executor())) {}
+WebSocketConnection::WriteChain::WriteChain(tcp_socket& sock) : socket(sock) {}
 
-boost::asio::awaitable<void> WebSocketConnection::AsyncWriteState::sendFrame(std::vector<uint8_t> frame) {
+void WebSocketConnection::WriteChain::enqueueOnExecutor(PendingWrite item) {
+    queue.push_back(std::move(item));
+    startPumpIfNeeded();
+}
+
+void WebSocketConnection::WriteChain::startPumpIfNeeded() {
+    if (pumping || queue.empty()) {
+        return;
+    }
+    pumping = true;
+    const std::shared_ptr<WriteChain> self = shared_from_this();
+    boost::asio::co_spawn(
+        socket.get_executor(),
+        [self]() -> boost::asio::awaitable<void> { co_await self->pump(); },
+        boost::asio::detached);
+}
+
+boost::asio::awaitable<void> WebSocketConnection::WriteChain::pump() {
+    while (true) {
+        PendingWrite item;
+        if (queue.empty()) {
+            pumping = false;
+            if (queue.empty()) {
+                co_return;
+            }
+            pumping = true;
+            continue;
+        }
+        item = std::move(queue.front());
+        queue.pop_front();
+
+        if (!writesEnabled.load(std::memory_order_relaxed)) {
+            if (item.onComplete) {
+                item.onComplete();
+            }
+            pumping = false;
+            co_return;
+        }
+
+        try {
+            co_await boost::asio::async_write(socket, boost::asio::buffer(item.frame),
+                                              boost::asio::use_awaitable);
+        } catch (...) {
+            writesEnabled.store(false, std::memory_order_relaxed);
+            if (item.onComplete) {
+                item.onComplete();
+            }
+            pumping = false;
+            co_return;
+        }
+
+        if (item.onComplete) {
+            item.onComplete();
+        }
+    }
+}
+
+void WebSocketConnection::WriteChain::schedule(std::vector<uint8_t> frame) {
+    if (!writesEnabled.load(std::memory_order_relaxed)) {
+        return;
+    }
+    const std::shared_ptr<WriteChain> self = shared_from_this();
+    boost::asio::post(socket.get_executor(), [self, f = std::move(frame)]() mutable {
+        if (!self->writesEnabled.load(std::memory_order_relaxed)) {
+            return;
+        }
+        self->enqueueOnExecutor(PendingWrite{std::move(f), nullptr});
+    });
+}
+
+boost::asio::awaitable<void> WebSocketConnection::WriteChain::write(std::vector<uint8_t> frame) {
     if (!writesEnabled.load(std::memory_order_relaxed)) {
         co_return;
     }
-    try {
-        co_await boost::asio::async_write(socket, boost::asio::buffer(frame), boost::asio::use_awaitable);
-    } catch (...) {
-        writesEnabled.store(false, std::memory_order_relaxed);
+    struct Gate {
+        bool done = false;
+    };
+    const std::shared_ptr<Gate>          gate = std::make_shared<Gate>();
+    const std::shared_ptr<WriteChain>    self = shared_from_this();
+    boost::asio::post(socket.get_executor(), [self, gate, f = std::move(frame)]() mutable {
+        if (!self->writesEnabled.load(std::memory_order_relaxed)) {
+            gate->done = true;
+            return;
+        }
+        self->enqueueOnExecutor(PendingWrite{std::move(f), [gate]() { gate->done = true; }});
+    });
+    while (!gate->done) {
+        co_await boost::asio::post(socket.get_executor(), boost::asio::use_awaitable);
     }
     co_return;
 }
@@ -429,28 +508,27 @@ boost::asio::awaitable<void> WebSocketConnection::AsyncWriteState::sendFrame(std
 WebSocketConnection::WebSocketConnection(tcp_socket& sock, std::string clientIp,
                                          std::string selectedSubprotocol, WebSocketLimits limits)
     : _socket(sock)
-    , _strand(boost::asio::make_strand(sock.get_executor()))
-    , _asyncWrite(std::make_shared<AsyncWriteState>(sock))
+    , _writeChain(std::make_shared<WriteChain>(sock))
     , _clientIp(std::move(clientIp))
     , _selectedSubprotocol(std::move(selectedSubprotocol))
     , _limits(std::move(limits)) {}
 
 void WebSocketConnection::markClosed(uint16_t code, std::string_view reason) {
     _open = false;
-    if (_asyncWrite) {
-        _asyncWrite->writesEnabled.store(false, std::memory_order_relaxed);
+    if (_writeChain) {
+        _writeChain->writesEnabled.store(false, std::memory_order_relaxed);
     }
     _closeCode = code;
     _closeReason.assign(reason);
 }
 
 boost::asio::awaitable<void> WebSocketConnection::writeCloseFrame(uint16_t code, std::string_view reason) {
+    if (!_writeChain) {
+        co_return;
+    }
     try {
-        co_await boost::asio::async_write(
-            _socket,
-            boost::asio::buffer(websocket_codec::encodeServerFrame(
-                WSOpcode::Close, WSMessage::makeClose(code, reason).data())),
-            boost::asio::use_awaitable);
+        co_await _writeChain->write(websocket_codec::encodeServerFrame(
+            WSOpcode::Close, WSMessage::makeClose(code, reason).data()));
     } catch (...) {
     }
     co_return;
@@ -463,11 +541,11 @@ boost::asio::awaitable<void> WebSocketConnection::protocolError(uint16_t code, s
 }
 
 boost::asio::awaitable<void> WebSocketConnection::writeRawFrame(std::vector<uint8_t> frame) {
-    if (!_open) {
+    if (!_open || !_writeChain) {
         co_return;
     }
     try {
-        co_await boost::asio::async_write(_socket, boost::asio::buffer(frame), boost::asio::use_awaitable);
+        co_await _writeChain->write(std::move(frame));
     } catch (...) {
         markClosed(1011, "write failed");
         throw;
@@ -512,35 +590,19 @@ boost::asio::awaitable<void> WebSocketConnection::close(uint16_t code, std::stri
 }
 
 void WebSocketConnection::sendNow(std::string_view text) {
-    const auto* begin = reinterpret_cast<const uint8_t*>(text.data());
-    auto        frame = websocket_codec::encodeServerFrame(WSOpcode::Text,
-                                                    std::span<const uint8_t>(begin, text.size()));
-    const std::shared_ptr<AsyncWriteState> state = _asyncWrite;
-    if (!state) {
+    if (!_writeChain) {
         return;
     }
-    boost::asio::co_spawn(
-        state->strand,
-        [state, frame = std::move(frame)]() mutable -> boost::asio::awaitable<void> {
-            co_await state->sendFrame(std::move(frame));
-            co_return;
-        },
-        boost::asio::detached);
+    const auto* begin = reinterpret_cast<const uint8_t*>(text.data());
+    _writeChain->schedule(websocket_codec::encodeServerFrame(
+        WSOpcode::Text, std::span<const uint8_t>(begin, text.size())));
 }
 
 void WebSocketConnection::sendBinaryNow(std::span<const uint8_t> data) {
-    auto                                   frame = websocket_codec::encodeServerFrame(WSOpcode::Binary, data);
-    const std::shared_ptr<AsyncWriteState> state   = _asyncWrite;
-    if (!state) {
+    if (!_writeChain) {
         return;
     }
-    boost::asio::co_spawn(
-        state->strand,
-        [state, frame = std::move(frame)]() mutable -> boost::asio::awaitable<void> {
-            co_await state->sendFrame(std::move(frame));
-            co_return;
-        },
-        boost::asio::detached);
+    _writeChain->schedule(websocket_codec::encodeServerFrame(WSOpcode::Binary, data));
 }
 
 boost::asio::awaitable<WSMessage> WebSocketConnection::readMessage() {

--- a/src/server/WebSocket.hpp
+++ b/src/server/WebSocket.hpp
@@ -10,6 +10,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/strand.hpp>
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -81,8 +82,19 @@ class WebSocketConnection {
     const std::string& selectedSubprotocol() const noexcept { return _selectedSubprotocol; }
 
    private:
+    struct AsyncWriteState : std::enable_shared_from_this<AsyncWriteState> {
+        explicit AsyncWriteState(tcp_socket& sock);
+
+        tcp_socket&                                    socket;
+        boost::asio::strand<tcp_socket::executor_type> strand;
+        std::atomic<bool>                              writesEnabled{true};
+
+        boost::asio::awaitable<void> sendFrame(std::vector<uint8_t> frame);
+    };
+
     tcp_socket&                                    _socket;
     boost::asio::strand<tcp_socket::executor_type> _strand;
+    std::shared_ptr<AsyncWriteState>               _asyncWrite;
     std::string                                    _clientIp;
     std::string                                    _selectedSubprotocol;
     WebSocketLimits                                _limits;
@@ -93,6 +105,7 @@ class WebSocketConnection {
 
     boost::asio::awaitable<void> writeFrame(WSOpcode op, std::span<const uint8_t> payload, bool fin = true);
     boost::asio::awaitable<void> writeRawFrame(std::vector<uint8_t> frame);
+    boost::asio::awaitable<void> writeCloseFrame(uint16_t code, std::string_view reason);
     boost::asio::awaitable<WSMessage> readMessage();
     boost::asio::awaitable<void>      protocolError(uint16_t code, std::string_view reason);
     void                              markClosed(uint16_t code, std::string_view reason);
@@ -111,6 +124,8 @@ WebSocketHandler adaptWebSocketRoute(WebSocketRoute route);
 
 // Handshake helpers (Handler + unit tests)
 [[nodiscard]] bool        isWebSocketUpgrade(const HTTPRequest& req);
+/** True when Upgrade header lists websocket (may still fail full upgrade validation). */
+[[nodiscard]] bool        isWebSocketUpgradeIntent(const HTTPRequest& req);
 [[nodiscard]] std::string computeAcceptKey(std::string_view secKey);
 [[nodiscard]] std::string buildHandshakeResponse(std::string_view acceptKey,
                                                  std::string_view subprotocol = {});

--- a/src/server/WebSocket.hpp
+++ b/src/server/WebSocket.hpp
@@ -1,0 +1,133 @@
+/**
+ * @file server/WebSocket.hpp
+ * @brief WebSocket handshake helpers, message types, and connection API.
+ */
+
+#ifndef GERUEST_WEBSOCKET_HPP
+#define GERUEST_WEBSOCKET_HPP
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/strand.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "data/HTTPRequest.hpp"
+#include "server/WebSocketTypes.hpp"
+
+namespace geruest {
+
+class WSMessage {
+   public:
+    WSOpcode opcode() const noexcept { return _opcode; }
+    bool     isText() const noexcept { return _opcode == WSOpcode::Text; }
+    bool     isBinary() const noexcept { return _opcode == WSOpcode::Binary; }
+    bool     isClose() const noexcept { return _opcode == WSOpcode::Close; }
+    bool     isPing() const noexcept { return _opcode == WSOpcode::Ping; }
+    bool     isPong() const noexcept { return _opcode == WSOpcode::Pong; }
+
+    std::string_view text() const noexcept {
+        return std::string_view(reinterpret_cast<const char*>(_payload.data()), _payload.size());
+    }
+    const std::vector<uint8_t>& data() const noexcept { return _payload; }
+    std::vector<uint8_t>        takeData() && { return std::move(_payload); }
+
+    uint16_t         closeCode() const noexcept { return _closeCode; }
+    std::string_view closeReason() const noexcept { return _closeReason; }
+
+    static WSMessage makeText(std::string_view text);
+    static WSMessage makeBinary(std::span<const uint8_t> data);
+    static WSMessage makeClose(uint16_t code, std::string_view reason);
+
+    static WSMessage makePing(std::vector<uint8_t> payload);
+    static WSMessage makePong(std::vector<uint8_t> payload);
+
+   private:
+    friend class WebSocketConnection;
+
+    WSOpcode             _opcode = WSOpcode::Text;
+    std::vector<uint8_t> _payload;
+    uint16_t             _closeCode = 1005;
+    std::string          _closeReason;
+};
+
+class WebSocketConnection {
+   public:
+    using tcp_socket = boost::asio::ip::tcp::socket;
+
+    WebSocketConnection(tcp_socket& sock, std::string clientIp, std::string selectedSubprotocol,
+                        WebSocketLimits limits);
+
+    boost::asio::awaitable<WSMessage> recv();
+    boost::asio::awaitable<void>      send(std::string_view text);
+    boost::asio::awaitable<void>      sendBinary(std::span<const uint8_t> data);
+    boost::asio::awaitable<void>      ping(std::span<const uint8_t> payload = {});
+    boost::asio::awaitable<void>      pong(std::span<const uint8_t> payload = {});
+    boost::asio::awaitable<void>      close(uint16_t code = 1000, std::string_view reason = "");
+
+    void sendNow(std::string_view text);
+    void sendBinaryNow(std::span<const uint8_t> data);
+
+    bool               isOpen() const noexcept { return _open; }
+    uint16_t           closeCode() const noexcept { return _closeCode; }
+    std::string_view   closeReason() const noexcept { return _closeReason; }
+    const std::string& clientIp() const noexcept { return _clientIp; }
+    const std::string& selectedSubprotocol() const noexcept { return _selectedSubprotocol; }
+
+   private:
+    tcp_socket&                                    _socket;
+    boost::asio::strand<tcp_socket::executor_type> _strand;
+    std::string                                    _clientIp;
+    std::string                                    _selectedSubprotocol;
+    WebSocketLimits                                _limits;
+
+    bool        _open = true;
+    uint16_t    _closeCode = 1005;
+    std::string _closeReason;
+
+    boost::asio::awaitable<void> writeFrame(WSOpcode op, std::span<const uint8_t> payload, bool fin = true);
+    boost::asio::awaitable<void> writeRawFrame(std::vector<uint8_t> frame);
+    boost::asio::awaitable<WSMessage> readMessage();
+    boost::asio::awaitable<void>      protocolError(uint16_t code, std::string_view reason);
+    void                              markClosed(uint16_t code, std::string_view reason);
+};
+
+struct WebSocketRoute {
+    std::function<void(WebSocketConnection&, const HTTPRequest&)>         onOpen;
+    std::function<void(WebSocketConnection&, WSMessage)>                  onMessage;
+    std::function<void(WebSocketConnection&, uint16_t, std::string_view)> onClose;
+};
+
+using WebSocketHandler =
+    std::function<boost::asio::awaitable<void>(WebSocketConnection&, const HTTPRequest&)>;
+
+WebSocketHandler adaptWebSocketRoute(WebSocketRoute route);
+
+// Handshake helpers (Handler + unit tests)
+[[nodiscard]] bool        isWebSocketUpgrade(const HTTPRequest& req);
+[[nodiscard]] std::string computeAcceptKey(std::string_view secKey);
+[[nodiscard]] std::string buildHandshakeResponse(std::string_view acceptKey,
+                                                 std::string_view subprotocol = {});
+[[nodiscard]] std::string pickSubprotocol(std::string_view clientHeader,
+                                          const std::vector<std::string>& serverOffered);
+
+// Codec helpers exposed for unit tests
+namespace websocket_codec {
+
+[[nodiscard]] std::string sha1Hash(std::string_view input);
+[[nodiscard]] std::vector<uint8_t> encodeServerFrame(WSOpcode opcode, std::span<const uint8_t> payload,
+                                                      bool fin = true);
+[[nodiscard]] WSMessage decodeClientFrame(std::span<const uint8_t> bytes, const WebSocketLimits& limits,
+                                        std::span<const uint8_t>* remainder = nullptr);
+
+}  // namespace websocket_codec
+
+}  // namespace geruest
+
+#endif  // GERUEST_WEBSOCKET_HPP

--- a/src/server/WebSocket.hpp
+++ b/src/server/WebSocket.hpp
@@ -8,10 +8,9 @@
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/strand.hpp>
-
 #include <atomic>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <span>
@@ -82,19 +81,29 @@ class WebSocketConnection {
     const std::string& selectedSubprotocol() const noexcept { return _selectedSubprotocol; }
 
    private:
-    struct AsyncWriteState : std::enable_shared_from_this<AsyncWriteState> {
-        explicit AsyncWriteState(tcp_socket& sock);
+    /** Serializes all outbound frames on the connection socket executor (session strand). */
+    struct WriteChain : std::enable_shared_from_this<WriteChain> {
+        explicit WriteChain(tcp_socket& sock);
 
-        tcp_socket&                                    socket;
-        boost::asio::strand<tcp_socket::executor_type> strand;
-        std::atomic<bool>                              writesEnabled{true};
+        struct PendingWrite {
+            std::vector<uint8_t> frame;
+            std::function<void()> onComplete;
+        };
 
-        boost::asio::awaitable<void> sendFrame(std::vector<uint8_t> frame);
+        tcp_socket&              socket;
+        std::atomic<bool>        writesEnabled{true};
+        std::deque<PendingWrite> queue;
+        bool                     pumping = false;
+
+        void                         enqueueOnExecutor(PendingWrite item);
+        void                         startPumpIfNeeded();
+        boost::asio::awaitable<void> pump();
+        void                         schedule(std::vector<uint8_t> frame);
+        boost::asio::awaitable<void> write(std::vector<uint8_t> frame);
     };
 
-    tcp_socket&                                    _socket;
-    boost::asio::strand<tcp_socket::executor_type> _strand;
-    std::shared_ptr<AsyncWriteState>               _asyncWrite;
+    tcp_socket&                    _socket;
+    std::shared_ptr<WriteChain>    _writeChain;
     std::string                                    _clientIp;
     std::string                                    _selectedSubprotocol;
     WebSocketLimits                                _limits;

--- a/src/server/WebSocketTypes.hpp
+++ b/src/server/WebSocketTypes.hpp
@@ -1,0 +1,33 @@
+/**
+ * @file server/WebSocketTypes.hpp
+ * @brief Shared WebSocket types (limits, opcodes) for ServerData and WebSocketConnection.
+ */
+
+#ifndef GERUEST_WEBSOCKETTYPES_HPP
+#define GERUEST_WEBSOCKETTYPES_HPP
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+namespace geruest {
+
+enum class WSOpcode : uint8_t {
+    Continuation = 0x0,
+    Text         = 0x1,
+    Binary       = 0x2,
+    Close        = 0x8,
+    Ping         = 0x9,
+    Pong         = 0xA,
+};
+
+struct WebSocketLimits {
+    size_t               maxFrameBytes   = 4 * 1024 * 1024;
+    size_t               maxMessageBytes = 16 * 1024 * 1024;
+    std::chrono::seconds idleTimeout{0};
+    std::chrono::seconds pingInterval{0};
+};
+
+}  // namespace geruest
+
+#endif  // GERUEST_WEBSOCKETTYPES_HPP

--- a/src/unitTests/CMakeLists.txt
+++ b/src/unitTests/CMakeLists.txt
@@ -81,6 +81,7 @@ set(GERUEST_SOURCES
     ../server/Socket.cpp
     ../server/Workers.cpp
     ../server/HttpSession.cpp
+    ../server/WebSocket.cpp
     ../server/Status.cpp
     ../auth/BasicAuth.cpp
     ../config/ConfigLoader.cpp
@@ -196,6 +197,54 @@ add_executable(Security_Tests
 )
 target_link_libraries(Security_Tests ${PLATFORM_LIBS} GTest::gtest_main)
 
+add_executable(WebSocketCodec_Tests
+    WebSocket/WebSocketCodec_tests.cpp
+    ../server/WebSocket.cpp
+    ../data/HTTPRequest.cpp
+    ../parser/JSONParser.cpp
+    ../auth/BasicAuth.cpp
+    ../security/Security.cpp
+)
+target_link_libraries(WebSocketCodec_Tests ${PLATFORM_LIBS} GTest::gtest_main)
+
+add_executable(WebSocketHandshake_Tests
+    WebSocket/WebSocketHandshake_tests.cpp
+    ../server/WebSocket.cpp
+    ../data/HTTPRequest.cpp
+    ../data/HTTPResponse.cpp
+    ../data/MethodNotAllowed.cpp
+    ../parser/JSONParser.cpp
+    ../auth/BasicAuth.cpp
+    ../security/Security.cpp
+)
+target_link_libraries(WebSocketHandshake_Tests ${PLATFORM_LIBS} GTest::gtest_main)
+
+add_executable(WebSocketServerData_Tests
+    WebSocket/WebSocketServerData_tests.cpp
+    ../data/ServerData.cpp
+    ../data/HTTPRequest.cpp
+    ../server/WebSocket.cpp
+    ../parser/JSONParser.cpp
+    ../auth/BasicAuth.cpp
+    ../security/Security.cpp
+)
+target_link_libraries(WebSocketServerData_Tests ${PLATFORM_LIBS} GTest::gtest_main)
+
+add_executable(WebSocketIntegration_Tests
+    WebSocket/WebSocketIntegration_tests.cpp
+    ${GERUEST_SOURCES}
+)
+target_link_libraries(WebSocketIntegration_Tests ${PLATFORM_LIBS} GTest::gtest_main)
+if(GERUEST_HAS_CURL)
+    target_link_libraries(WebSocketIntegration_Tests CURL::libcurl)
+endif()
+if(GERUEST_HAS_SQLITE)
+    target_link_libraries(WebSocketIntegration_Tests SQLite::SQLite3)
+endif()
+if(GERUEST_HAS_LIBPQ)
+    target_link_libraries(WebSocketIntegration_Tests PostgreSQL::PostgreSQL)
+endif()
+
 add_executable(ServerDataMetricsPersistence_Tests
     ServerData/ServerDataMetricsPersistence_tests.cpp
     ../data/ServerData.cpp
@@ -273,6 +322,10 @@ gtest_discover_tests(BasicAuth_Tests)
 gtest_discover_tests(ConfigLoader_Tests)
 gtest_discover_tests(AssetMerger_Tests)
 gtest_discover_tests(Security_Tests)
+gtest_discover_tests(WebSocketCodec_Tests)
+gtest_discover_tests(WebSocketHandshake_Tests)
+gtest_discover_tests(WebSocketServerData_Tests)
+gtest_discover_tests(WebSocketIntegration_Tests)
 gtest_discover_tests(ServerDataMetricsPersistence_Tests)
 gtest_discover_tests(ServerDataRedirectLanguage_Tests)
 gtest_discover_tests(GeruestLifecycle_Tests)
@@ -304,13 +357,13 @@ exit $rc
 ]=])
     add_custom_target(run_tests
         COMMAND bash "${CMAKE_CURRENT_BINARY_DIR}/run_tests_pg.sh" "${CMAKE_CTEST_COMMAND}"
-        DEPENDS JSONParser_Tests HTTPRequest_Tests HTTPResponse_Tests FileManagement_Tests ContentBuilder_Tests JSObfuscator_Tests BasicAuth_Tests ConfigLoader_Tests AssetMerger_Tests Security_Tests ServerDataMetricsPersistence_Tests ServerDataRedirectLanguage_Tests GeruestLifecycle_Tests DatabasePostgres_Tests
+        DEPENDS JSONParser_Tests HTTPRequest_Tests HTTPResponse_Tests FileManagement_Tests ContentBuilder_Tests JSObfuscator_Tests BasicAuth_Tests ConfigLoader_Tests AssetMerger_Tests Security_Tests WebSocketCodec_Tests WebSocketHandshake_Tests WebSocketServerData_Tests WebSocketIntegration_Tests ServerDataMetricsPersistence_Tests ServerDataRedirectLanguage_Tests GeruestLifecycle_Tests DatabasePostgres_Tests
         COMMENT "Running all unit tests via CTest (with PostgreSQL container)"
     )
 else()
     add_custom_target(run_tests
         COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --verbose
-        DEPENDS JSONParser_Tests HTTPRequest_Tests HTTPResponse_Tests FileManagement_Tests ContentBuilder_Tests JSObfuscator_Tests BasicAuth_Tests ConfigLoader_Tests AssetMerger_Tests Security_Tests ServerDataMetricsPersistence_Tests ServerDataRedirectLanguage_Tests GeruestLifecycle_Tests
+        DEPENDS JSONParser_Tests HTTPRequest_Tests HTTPResponse_Tests FileManagement_Tests ContentBuilder_Tests JSObfuscator_Tests BasicAuth_Tests ConfigLoader_Tests AssetMerger_Tests Security_Tests WebSocketCodec_Tests WebSocketHandshake_Tests WebSocketServerData_Tests WebSocketIntegration_Tests ServerDataMetricsPersistence_Tests ServerDataRedirectLanguage_Tests GeruestLifecycle_Tests
         COMMENT "Running all unit tests via CTest"
     )
 endif()

--- a/src/unitTests/CMakeLists.txt
+++ b/src/unitTests/CMakeLists.txt
@@ -205,6 +205,15 @@ add_executable(ServerDataMetricsPersistence_Tests
 )
 target_link_libraries(ServerDataMetricsPersistence_Tests ${PLATFORM_LIBS} GTest::gtest_main)
 
+add_executable(ServerDataRedirectLanguage_Tests
+    ServerData/ServerDataRedirectLanguage_tests.cpp
+    ../data/ServerData.cpp
+    ../parser/JSONParser.cpp
+    ../auth/BasicAuth.cpp
+    ../security/Security.cpp
+)
+target_link_libraries(ServerDataRedirectLanguage_Tests ${PLATFORM_LIBS} GTest::gtest_main)
+
 add_executable(GeruestLifecycle_Tests
     Geruest/GeruestLifecycle_tests.cpp
     ${GERUEST_SOURCES}
@@ -265,6 +274,7 @@ gtest_discover_tests(ConfigLoader_Tests)
 gtest_discover_tests(AssetMerger_Tests)
 gtest_discover_tests(Security_Tests)
 gtest_discover_tests(ServerDataMetricsPersistence_Tests)
+gtest_discover_tests(ServerDataRedirectLanguage_Tests)
 gtest_discover_tests(GeruestLifecycle_Tests)
 if(GERUEST_HAS_SQLITE)
     gtest_discover_tests(DatabaseSqlite_Tests)
@@ -294,13 +304,13 @@ exit $rc
 ]=])
     add_custom_target(run_tests
         COMMAND bash "${CMAKE_CURRENT_BINARY_DIR}/run_tests_pg.sh" "${CMAKE_CTEST_COMMAND}"
-        DEPENDS JSONParser_Tests HTTPRequest_Tests HTTPResponse_Tests FileManagement_Tests ContentBuilder_Tests JSObfuscator_Tests BasicAuth_Tests ConfigLoader_Tests AssetMerger_Tests Security_Tests ServerDataMetricsPersistence_Tests GeruestLifecycle_Tests DatabasePostgres_Tests
+        DEPENDS JSONParser_Tests HTTPRequest_Tests HTTPResponse_Tests FileManagement_Tests ContentBuilder_Tests JSObfuscator_Tests BasicAuth_Tests ConfigLoader_Tests AssetMerger_Tests Security_Tests ServerDataMetricsPersistence_Tests ServerDataRedirectLanguage_Tests GeruestLifecycle_Tests DatabasePostgres_Tests
         COMMENT "Running all unit tests via CTest (with PostgreSQL container)"
     )
 else()
     add_custom_target(run_tests
         COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --verbose
-        DEPENDS JSONParser_Tests HTTPRequest_Tests HTTPResponse_Tests FileManagement_Tests ContentBuilder_Tests JSObfuscator_Tests BasicAuth_Tests ConfigLoader_Tests AssetMerger_Tests Security_Tests ServerDataMetricsPersistence_Tests GeruestLifecycle_Tests
+        DEPENDS JSONParser_Tests HTTPRequest_Tests HTTPResponse_Tests FileManagement_Tests ContentBuilder_Tests JSObfuscator_Tests BasicAuth_Tests ConfigLoader_Tests AssetMerger_Tests Security_Tests ServerDataMetricsPersistence_Tests ServerDataRedirectLanguage_Tests GeruestLifecycle_Tests
         COMMENT "Running all unit tests via CTest"
     )
 endif()

--- a/src/unitTests/CMakeLists.txt
+++ b/src/unitTests/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.28)
-project(Geruest_Unit_Tests VERSION 0.6.2)
+
+# Keep test Version.hpp in sync with GeruestLibrary (separate CMake project).
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeLists.txt" GERUEST_ROOT_CMAKELISTS)
+string(REGEX MATCH "project\\(GeruestLibrary VERSION ([0-9]+\\.[0-9]+\\.[0-9]+)" _ "${GERUEST_ROOT_CMAKELISTS}")
+if(NOT CMAKE_MATCH_1)
+    message(FATAL_ERROR "Could not parse Geruest library version from root CMakeLists.txt")
+endif()
+project(Geruest_Unit_Tests VERSION ${CMAKE_MATCH_1})
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/unitTests/HTTPRequest/HTTPRequest_tests.cpp
+++ b/src/unitTests/HTTPRequest/HTTPRequest_tests.cpp
@@ -118,3 +118,13 @@ TEST(HTTPRequestTest, HttpExpect100ContinueMatcher) {
     EXPECT_FALSE(httpExpectIs100Continue(""));
     EXPECT_FALSE(httpExpectIs100Continue("100"));
 }
+
+TEST(HTTPRequestTest, HttpShouldCloseAfterResponse) {
+    EXPECT_TRUE(httpShouldCloseAfterResponse("GET / HTTP/1.1", "close"));
+    EXPECT_TRUE(httpShouldCloseAfterResponse("GET / HTTP/1.1", "Close"));
+    EXPECT_TRUE(httpShouldCloseAfterResponse("GET / HTTP/1.1", "keep-alive, close"));
+    EXPECT_FALSE(httpShouldCloseAfterResponse("GET / HTTP/1.1", "keep-alive"));
+    EXPECT_FALSE(httpShouldCloseAfterResponse("GET / HTTP/1.1", ""));
+    EXPECT_TRUE(httpShouldCloseAfterResponse("GET / HTTP/1.0", ""));
+    EXPECT_FALSE(httpShouldCloseAfterResponse("GET / HTTP/1.0", "keep-alive"));
+}

--- a/src/unitTests/ServerData/ServerDataRedirectLanguage_tests.cpp
+++ b/src/unitTests/ServerData/ServerDataRedirectLanguage_tests.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include "data/ServerData.hpp"
+
+using namespace geruest;
+
+TEST(ServerDataRedirectLanguage, ExactRedirectPreservesRequestLanguagePrefix) {
+    ServerData sd;
+    sd.setAvailableLanguages({"en", "de"});
+
+    ASSERT_TRUE(sd.addRedirect("/something", "/redirection"));
+    const auto match = sd.findMatchingRedirect("/de/something");
+
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->first, "/de/redirection");
+    EXPECT_EQ(match->second, 301);
+}
+
+TEST(ServerDataRedirectLanguage, WildcardRedirectPreservesRequestLanguagePrefix) {
+    ServerData sd;
+    sd.setAvailableLanguages({"en", "de"});
+
+    ASSERT_TRUE(sd.addRedirect("*/redirect", "/redirection"));
+    const auto match = sd.findMatchingRedirect("/de/something/redirect");
+
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->first, "/de/redirection");
+    EXPECT_EQ(match->second, 301);
+}
+
+TEST(ServerDataRedirectLanguage, ExplicitLanguageTargetStaysUnchanged) {
+    ServerData sd;
+    sd.setAvailableLanguages({"en", "de"});
+
+    ASSERT_TRUE(sd.addRedirect("*/redirect", "/en/redirection"));
+    const auto match = sd.findMatchingRedirect("/de/something/redirect");
+
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->first, "/en/redirection");
+}
+
+TEST(ServerDataRedirectLanguage, NoLanguageInRequestKeepsExistingBehavior) {
+    ServerData sd;
+    sd.setAvailableLanguages({"en", "de"});
+
+    ASSERT_TRUE(sd.addRedirect("/something", "/redirection"));
+    const auto match = sd.findMatchingRedirect("/something");
+
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->first, "/redirection");
+}
+
+TEST(ServerDataRedirectLanguage, ExternalTargetNeverChanged) {
+    ServerData sd;
+    sd.setAvailableLanguages({"en", "de"});
+
+    ASSERT_TRUE(sd.addRedirect("/something", "https://example.com/path"));
+    const auto match = sd.findMatchingRedirect("/de/something");
+
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->first, "https://example.com/path");
+}

--- a/src/unitTests/WebSocket/WebSocketCodec_tests.cpp
+++ b/src/unitTests/WebSocket/WebSocketCodec_tests.cpp
@@ -1,0 +1,142 @@
+/**
+ * @file WebSocketCodec_tests.cpp
+ * @brief Unit tests for WebSocket crypto and frame codec helpers.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "../../security/Base64.hpp"
+#include "../../server/WebSocket.hpp"
+
+using namespace geruest;
+using namespace geruest::websocket_codec;
+
+namespace {
+
+std::vector<uint8_t> encodeMaskedClientFrame(WSOpcode opcode, std::span<const uint8_t> payload, bool fin = true,
+                                             const uint8_t mask[4] = nullptr) {
+    static const uint8_t kDefaultMask[4] = {0x37, 0xFA, 0x21, 0x3D};
+    if (mask == nullptr) {
+        mask = kDefaultMask;
+    }
+
+    std::vector<uint8_t> frame;
+    uint8_t b0 = static_cast<uint8_t>(opcode) & 0x0F;
+    if (fin) {
+        b0 |= 0x80;
+    }
+    frame.push_back(b0);
+
+    const size_t len = payload.size();
+    if (len < 126) {
+        frame.push_back(static_cast<uint8_t>(0x80 | len));
+    } else if (len <= 0xFFFF) {
+        frame.push_back(static_cast<uint8_t>(0x80 | 126));
+        frame.push_back(static_cast<uint8_t>((len >> 8) & 0xFF));
+        frame.push_back(static_cast<uint8_t>(len & 0xFF));
+    } else {
+        frame.push_back(static_cast<uint8_t>(0x80 | 127));
+        for (int shift = 56; shift >= 0; shift -= 8) {
+            frame.push_back(static_cast<uint8_t>((len >> shift) & 0xFF));
+        }
+    }
+
+    frame.insert(frame.end(), mask, mask + 4);
+    for (size_t i = 0; i < payload.size(); ++i) {
+        frame.push_back(static_cast<uint8_t>(payload[i] ^ mask[i % 4]));
+    }
+    return frame;
+}
+
+}  // namespace
+
+TEST(WebSocketCodec, Sha1Empty) {
+    const std::string digest = sha1Hash("");
+    EXPECT_EQ(digest.size(), 20U);
+    std::string hex;
+    for (unsigned char c : digest) {
+        char buf[3];
+        snprintf(buf, sizeof(buf), "%02x", c);
+        hex += buf;
+    }
+    EXPECT_EQ(hex, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+}
+
+TEST(WebSocketCodec, Sha1Abc) {
+    const std::string digest = sha1Hash("abc");
+    std::string hex;
+    for (unsigned char c : digest) {
+        char buf[3];
+        snprintf(buf, sizeof(buf), "%02x", c);
+        hex += buf;
+    }
+    EXPECT_EQ(hex, "a9993e364706816aba3e25717850c26c9cd0d89d");
+}
+
+TEST(WebSocketCodec, Base64RfcVectors) {
+    EXPECT_EQ(base64Encode("f"), "Zg==");
+    EXPECT_EQ(base64Encode("fo"), "Zm8=");
+    EXPECT_EQ(base64Encode("foo"), "Zm9v");
+    EXPECT_EQ(base64Encode("foob"), "Zm9vYg==");
+}
+
+TEST(WebSocketCodec, Base64RoundTrip) {
+    std::string input;
+    for (int i = 0; i < 256; ++i) {
+        input.push_back(static_cast<char>(i));
+    }
+    EXPECT_EQ(base64Decode(base64Encode(input)), input);
+}
+
+TEST(WebSocketCodec, AcceptKeyRfcExample) {
+    EXPECT_EQ(computeAcceptKey("dGhlIHNhbXBsZSBub25jZQ=="), "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+}
+
+TEST(WebSocketCodec, EncodeServerTextHi) {
+    const auto frame = encodeServerFrame(WSOpcode::Text, std::span<const uint8_t>{
+        reinterpret_cast<const uint8_t*>("hi"), 2});
+    ASSERT_EQ(frame.size(), 4U);
+    EXPECT_EQ(frame[0], 0x81);
+    EXPECT_EQ(frame[1], 0x02);
+    EXPECT_EQ(frame[2], 'h');
+    EXPECT_EQ(frame[3], 'i');
+}
+
+TEST(WebSocketCodec, DecodeMaskedTextHi) {
+    WebSocketLimits limits;
+  const std::array<uint8_t, 2> payload = {'H', 'i'};
+    const auto bytes = encodeMaskedClientFrame(WSOpcode::Text, payload);
+    const WSMessage msg = decodeClientFrame(bytes, limits);
+    EXPECT_TRUE(msg.isText());
+    EXPECT_EQ(msg.text(), "Hi");
+}
+
+TEST(WebSocketCodec, RejectsUnmaskedClientFrame) {
+    WebSocketLimits limits;
+    const std::vector<uint8_t> bytes = {0x81, 0x02, 'h', 'i'};
+    EXPECT_THROW(decodeClientFrame(bytes, limits), std::runtime_error);
+}
+
+TEST(WebSocketCodec, DecodeCloseFrame) {
+    WebSocketLimits limits;
+    std::vector<uint8_t> payload = {0x03, 0xE9};
+    payload.insert(payload.end(), {'b', 'y', 'e'});
+    const auto bytes = encodeMaskedClientFrame(WSOpcode::Close, payload);
+    const WSMessage msg = decodeClientFrame(bytes, limits);
+    EXPECT_TRUE(msg.isClose());
+    EXPECT_EQ(msg.closeCode(), 1001);
+    EXPECT_EQ(msg.closeReason(), "bye");
+}
+
+TEST(WebSocketCodec, RejectsOversizedFrame) {
+    WebSocketLimits limits;
+    limits.maxFrameBytes = 8;
+    std::vector<uint8_t> payload(16, 'x');
+    const auto bytes = encodeMaskedClientFrame(WSOpcode::Text, payload);
+    EXPECT_THROW(decodeClientFrame(bytes, limits), std::runtime_error);
+}

--- a/src/unitTests/WebSocket/WebSocketHandshake_tests.cpp
+++ b/src/unitTests/WebSocket/WebSocketHandshake_tests.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file WebSocketHandshake_tests.cpp
+ * @brief Unit tests for WebSocket HTTP upgrade detection and handshake response.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "../../data/HTTPRequest.hpp"
+#include "../../server/WebSocket.hpp"
+
+using namespace geruest;
+
+namespace {
+
+HTTPRequest makeWsRequest(std::string raw) {
+    return HTTPRequest(std::move(raw), "127.0.0.1", "/root");
+}
+
+std::string canonicalHandshake() {
+    return "GET /chat HTTP/1.1\r\n"
+           "Host: example.com\r\n"
+           "Upgrade: websocket\r\n"
+           "Connection: Upgrade\r\n"
+           "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+           "Sec-WebSocket-Version: 13\r\n"
+           "\r\n";
+}
+
+}  // namespace
+
+TEST(WebSocketHandshake, AcceptsCanonical) {
+    const HTTPRequest req = makeWsRequest(canonicalHandshake());
+    EXPECT_TRUE(isWebSocketUpgrade(req));
+}
+
+TEST(WebSocketHandshake, AcceptsConnectionUpgradeMixedCase) {
+    std::string raw = "GET /chat HTTP/1.1\r\n"
+                      "Host: example.com\r\n"
+                      "Upgrade: websocket\r\n"
+                      "Connection: keep-alive, Upgrade\r\n"
+                      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                      "Sec-WebSocket-Version: 13\r\n"
+                      "\r\n";
+    const HTTPRequest req = makeWsRequest(std::move(raw));
+    EXPECT_TRUE(isWebSocketUpgrade(req));
+}
+
+TEST(WebSocketHandshake, RejectsPostMethod) {
+    std::string raw = "POST /chat HTTP/1.1\r\n"
+                      "Host: example.com\r\n"
+                      "Upgrade: websocket\r\n"
+                      "Connection: Upgrade\r\n"
+                      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                      "Sec-WebSocket-Version: 13\r\n"
+                      "\r\n";
+    const HTTPRequest req = makeWsRequest(std::move(raw));
+    EXPECT_FALSE(isWebSocketUpgrade(req));
+}
+
+TEST(WebSocketHandshake, RejectsMissingUpgrade) {
+    std::string raw = "GET /chat HTTP/1.1\r\n"
+                      "Host: example.com\r\n"
+                      "Connection: Upgrade\r\n"
+                      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                      "Sec-WebSocket-Version: 13\r\n"
+                      "\r\n";
+    const HTTPRequest req = makeWsRequest(std::move(raw));
+    EXPECT_FALSE(isWebSocketUpgrade(req));
+}
+
+TEST(WebSocketHandshake, RejectsWrongVersion) {
+    std::string raw = "GET /chat HTTP/1.1\r\n"
+                      "Host: example.com\r\n"
+                      "Upgrade: websocket\r\n"
+                      "Connection: Upgrade\r\n"
+                      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                      "Sec-WebSocket-Version: 8\r\n"
+                      "\r\n";
+    const HTTPRequest req = makeWsRequest(std::move(raw));
+    EXPECT_FALSE(isWebSocketUpgrade(req));
+}
+
+TEST(WebSocketHandshake, PickSubprotocolFirstClientMatch) {
+    const std::vector<std::string> server = {"superchat", "chat"};
+    EXPECT_EQ(pickSubprotocol("chat, superchat", server), "chat");
+}
+
+TEST(WebSocketHandshake, PickSubprotocolNoOverlap) {
+    const std::vector<std::string> server = {"chat"};
+    EXPECT_EQ(pickSubprotocol("xmpp", server), "");
+}
+
+TEST(WebSocketHandshake, BuildHandshakeResponseRequiredHeaders) {
+    const std::string resp = buildHandshakeResponse("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+    EXPECT_NE(resp.find("HTTP/1.1 101 Switching Protocols"), std::string::npos);
+    EXPECT_NE(resp.find("Upgrade: websocket"), std::string::npos);
+    EXPECT_NE(resp.find("Connection: Upgrade"), std::string::npos);
+    EXPECT_NE(resp.find("Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo="), std::string::npos);
+    EXPECT_EQ(resp.substr(resp.size() - 4), "\r\n\r\n");
+}
+
+TEST(WebSocketHandshake, BuildHandshakeResponseIncludesSubprotocol) {
+    const std::string resp = buildHandshakeResponse("accept", "chat");
+    EXPECT_NE(resp.find("Sec-WebSocket-Protocol: chat"), std::string::npos);
+}

--- a/src/unitTests/WebSocket/WebSocketHandshake_tests.cpp
+++ b/src/unitTests/WebSocket/WebSocketHandshake_tests.cpp
@@ -71,6 +71,29 @@ TEST(WebSocketHandshake, RejectsMissingUpgrade) {
     EXPECT_FALSE(isWebSocketUpgrade(req));
 }
 
+TEST(WebSocketHandshake, UpgradeIntentWithoutFullValidation) {
+    std::string raw = "GET /chat HTTP/1.1\r\n"
+                      "Host: example.com\r\n"
+                      "Upgrade: websocket\r\n"
+                      "Connection: Upgrade\r\n"
+                      "Sec-WebSocket-Version: 8\r\n"
+                      "\r\n";
+    const HTTPRequest req = makeWsRequest(std::move(raw));
+    EXPECT_TRUE(isWebSocketUpgradeIntent(req));
+    EXPECT_FALSE(isWebSocketUpgrade(req));
+}
+
+TEST(WebSocketHandshake, NoUpgradeIntentForH2c) {
+    std::string raw = "GET /api/ping HTTP/1.1\r\n"
+                      "Host: example.com\r\n"
+                      "Upgrade: h2c\r\n"
+                      "Connection: Upgrade, HTTP2-Settings\r\n"
+                      "\r\n";
+    const HTTPRequest req = makeWsRequest(std::move(raw));
+    EXPECT_FALSE(isWebSocketUpgradeIntent(req));
+    EXPECT_FALSE(isWebSocketUpgrade(req));
+}
+
 TEST(WebSocketHandshake, RejectsWrongVersion) {
     std::string raw = "GET /chat HTTP/1.1\r\n"
                       "Host: example.com\r\n"

--- a/src/unitTests/WebSocket/WebSocketIntegration_tests.cpp
+++ b/src/unitTests/WebSocket/WebSocketIntegration_tests.cpp
@@ -306,19 +306,12 @@ TEST(WebSocketIntegration, ServerSendsCloseFrameAfterHandler) {
     const auto frame = maskedTextFrame("bye");
     ASSERT_TRUE(sendAll(fd, frame.data(), frame.size()));
 
-    std::string payload;
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-    while (payload.find('\x88') == std::string::npos && std::chrono::steady_clock::now() < deadline) {
-        char buf[512];
-        const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
-        if (n > 0) {
-            payload.append(buf, static_cast<size_t>(n));
-        } else {
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
-        }
-    }
-    EXPECT_NE(payload.find("bye"), std::string::npos);
-    EXPECT_NE(payload.find('\x88'), std::string::npos);
+    const std::string echoed = readUnmaskedTextPayload(fd);
+    EXPECT_EQ(echoed, "bye");
+
+    std::string closeFrame;
+    ASSERT_TRUE(recvSome(fd, closeFrame, 2, 1000));
+    EXPECT_EQ(static_cast<unsigned char>(closeFrame[0]), 0x88u);
 
     close(fd);
     server.stop();

--- a/src/unitTests/WebSocket/WebSocketIntegration_tests.cpp
+++ b/src/unitTests/WebSocket/WebSocketIntegration_tests.cpp
@@ -1,0 +1,273 @@
+/**
+ * @file WebSocketIntegration_tests.cpp
+ * @brief End-to-end WebSocket tests over loopback TCP.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "Geruest.hpp"
+#include "server/WebSocket.hpp"
+
+using namespace geruest;
+
+namespace {
+
+int connectTo(int port) {
+    const int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast<uint16_t>(port));
+    inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+    if (connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+bool sendAll(int fd, const void* data, size_t len) {
+    const auto* p = static_cast<const uint8_t*>(data);
+    size_t sent = 0;
+    while (sent < len) {
+        const ssize_t n = ::send(fd, p + sent, len - sent, 0);
+        if (n <= 0) {
+            return false;
+        }
+        sent += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+bool recvSome(int fd, std::string& out, size_t minBytes, int timeoutMs = 3000) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+    while (out.size() < minBytes && std::chrono::steady_clock::now() < deadline) {
+        char buf[4096];
+        const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+        if (n <= 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+        out.append(buf, static_cast<size_t>(n));
+    }
+    return out.size() >= minBytes;
+}
+
+std::vector<uint8_t> maskedTextFrame(std::string_view text) {
+    const uint8_t mask[4] = {0x12, 0x34, 0x56, 0x78};
+    std::vector<uint8_t> frame;
+    frame.push_back(0x81);
+    frame.push_back(static_cast<uint8_t>(0x80 | text.size()));
+    frame.insert(frame.end(), mask, mask + 4);
+    for (size_t i = 0; i < text.size(); ++i) {
+        frame.push_back(static_cast<uint8_t>(text[i] ^ mask[i % 4]));
+    }
+    return frame;
+}
+
+std::string readUnmaskedTextPayload(int fd) {
+    std::string raw;
+    if (!recvSome(fd, raw, 4)) {
+        return {};
+    }
+    const size_t payloadLen = static_cast<unsigned char>(raw[1]) & 0x7F;
+    if (!recvSome(fd, raw, 2 + payloadLen)) {
+        return {};
+    }
+    return raw.substr(2, payloadLen);
+}
+
+void startServerOnBackground(Geruest& server) {
+    server.setPort(0);
+    server.setWorkerThreadCount(1);
+    server.setMaxQueueSize(8);
+    server.init();
+    std::thread([&server] { server.start(); }).detach();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (!server.isRunning() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+}
+
+}  // namespace
+
+TEST(WebSocketIntegration, CoroutineEcho) {
+    Geruest server;
+    server.addRouteWebSocket(
+        "/echo",
+        [](WebSocketConnection& ws, const HTTPRequest&) -> boost::asio::awaitable<void> {
+            WSMessage msg = co_await ws.recv();
+            if (msg.isText()) {
+                co_await ws.send(msg.text());
+            }
+            co_return;
+        });
+
+    startServerOnBackground(server);
+    const int port = server.getListenPort();
+    ASSERT_GT(port, 0);
+
+    const int fd = connectTo(port);
+    ASSERT_GE(fd, 0);
+
+    const std::string handshake =
+        "GET /echo HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n";
+    ASSERT_TRUE(sendAll(fd, handshake.data(), handshake.size()));
+
+    std::string response;
+    ASSERT_TRUE(recvSome(fd, response, 12));
+    EXPECT_NE(response.find("101 Switching Protocols"), std::string::npos);
+
+    const auto frame = maskedTextFrame("hello");
+    ASSERT_TRUE(sendAll(fd, frame.data(), frame.size()));
+
+    const std::string echoed = readUnmaskedTextPayload(fd);
+    EXPECT_EQ(echoed, "hello");
+
+    close(fd);
+    server.stop();
+}
+
+TEST(WebSocketIntegration, CallbackEcho) {
+    Geruest server;
+    WebSocketRoute route;
+    std::atomic<int> messageCount{0};
+    route.onMessage = [&messageCount](WebSocketConnection& ws, WSMessage msg) {
+        if (msg.isText()) {
+            ++messageCount;
+            ws.sendNow(msg.text());
+        }
+    };
+    server.addRouteWebSocket("/echo-cb", route);
+
+    startServerOnBackground(server);
+    const int fd = connectTo(server.getListenPort());
+    ASSERT_GE(fd, 0);
+
+    const std::string handshake =
+        "GET /echo-cb HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n";
+    ASSERT_TRUE(sendAll(fd, handshake.data(), handshake.size()));
+
+    std::string response;
+    ASSERT_TRUE(recvSome(fd, response, 12));
+
+    const auto frame = maskedTextFrame("ping");
+    ASSERT_TRUE(sendAll(fd, frame.data(), frame.size()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    const std::string echoed = readUnmaskedTextPayload(fd);
+    EXPECT_EQ(echoed, "ping");
+
+    close(fd);
+    server.stop();
+    EXPECT_GE(messageCount.load(), 1);
+}
+
+TEST(WebSocketIntegration, RejectsBadVersion) {
+    Geruest server;
+    server.addRouteWebSocket(
+        "/echo",
+        [](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> { co_return; });
+
+    startServerOnBackground(server);
+    const int fd = connectTo(server.getListenPort());
+    ASSERT_GE(fd, 0);
+
+    const std::string handshake =
+        "GET /echo HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "Sec-WebSocket-Version: 8\r\n"
+        "\r\n";
+    ASSERT_TRUE(sendAll(fd, handshake.data(), handshake.size()));
+
+    std::string response;
+    ASSERT_TRUE(recvSome(fd, response, 12));
+    EXPECT_NE(response.find("400 Bad Request"), std::string::npos);
+
+    close(fd);
+    server.stop();
+}
+
+TEST(WebSocketIntegration, RouteNotFoundReturns404) {
+    Geruest server;
+    startServerOnBackground(server);
+    const int fd = connectTo(server.getListenPort());
+    ASSERT_GE(fd, 0);
+
+    const std::string handshake =
+        "GET /missing-ws HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n";
+    ASSERT_TRUE(sendAll(fd, handshake.data(), handshake.size()));
+
+    std::string response;
+    ASSERT_TRUE(recvSome(fd, response, 12));
+    EXPECT_NE(response.find("404 Not Found"), std::string::npos);
+
+    close(fd);
+    server.stop();
+}
+
+TEST(WebSocketIntegration, NormalHttpStillWorks) {
+    Geruest server;
+    server.addRouteWebSocket(
+        "/ws",
+        [](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> { co_return; });
+    server.addRoute("/api/ping", [](const HTTPRequest&) {
+        HTTPResponse r("200 OK");
+        r.setHeader("Content-Type", "text/plain");
+        r.setBody("pong");
+        return r;
+    });
+
+    startServerOnBackground(server);
+    const int fd = connectTo(server.getListenPort());
+    ASSERT_GE(fd, 0);
+
+    const std::string request =
+        "GET /api/ping HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+    ASSERT_TRUE(sendAll(fd, request.data(), request.size()));
+
+    std::string response;
+    ASSERT_TRUE(recvSome(fd, response, 12));
+    EXPECT_NE(response.find("200 OK"), std::string::npos);
+    EXPECT_NE(response.find("pong"), std::string::npos);
+
+    close(fd);
+    server.stop();
+}

--- a/src/unitTests/WebSocket/WebSocketIntegration_tests.cpp
+++ b/src/unitTests/WebSocket/WebSocketIntegration_tests.cpp
@@ -240,6 +240,90 @@ TEST(WebSocketIntegration, RouteNotFoundReturns404) {
     server.stop();
 }
 
+TEST(WebSocketIntegration, NonWebSocketUpgradeReachesHttpRoute) {
+    Geruest server;
+    server.addRouteWebSocket(
+        "/ws",
+        [](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> { co_return; });
+    server.addRoute("/api/ping", [](const HTTPRequest&) {
+        HTTPResponse r("200 OK");
+        r.setHeader("Content-Type", "text/plain");
+        r.setBody("pong");
+        return r;
+    });
+
+    startServerOnBackground(server);
+    const int fd = connectTo(server.getListenPort());
+    ASSERT_GE(fd, 0);
+
+    const std::string request =
+        "GET /api/ping HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Upgrade: h2c\r\n"
+        "Connection: Upgrade, HTTP2-Settings\r\n"
+        "\r\n";
+    ASSERT_TRUE(sendAll(fd, request.data(), request.size()));
+
+    std::string response;
+    ASSERT_TRUE(recvSome(fd, response, 12));
+    EXPECT_NE(response.find("200 OK"), std::string::npos);
+    EXPECT_NE(response.find("pong"), std::string::npos);
+
+    close(fd);
+    server.stop();
+}
+
+TEST(WebSocketIntegration, ServerSendsCloseFrameAfterHandler) {
+    Geruest server;
+    server.addRouteWebSocket(
+        "/echo",
+        [](WebSocketConnection& ws, const HTTPRequest&) -> boost::asio::awaitable<void> {
+            WSMessage msg = co_await ws.recv();
+            if (msg.isText()) {
+                co_await ws.send(msg.text());
+            }
+            co_return;
+        });
+
+    startServerOnBackground(server);
+    const int fd = connectTo(server.getListenPort());
+    ASSERT_GE(fd, 0);
+
+    const std::string handshake =
+        "GET /echo HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n";
+    ASSERT_TRUE(sendAll(fd, handshake.data(), handshake.size()));
+
+    std::string response;
+    ASSERT_TRUE(recvSome(fd, response, 12));
+    EXPECT_NE(response.find("101 Switching Protocols"), std::string::npos);
+
+    const auto frame = maskedTextFrame("bye");
+    ASSERT_TRUE(sendAll(fd, frame.data(), frame.size()));
+
+    std::string payload;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (payload.find('\x88') == std::string::npos && std::chrono::steady_clock::now() < deadline) {
+        char buf[512];
+        const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+        if (n > 0) {
+            payload.append(buf, static_cast<size_t>(n));
+        } else {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+    EXPECT_NE(payload.find("bye"), std::string::npos);
+    EXPECT_NE(payload.find('\x88'), std::string::npos);
+
+    close(fd);
+    server.stop();
+}
+
 TEST(WebSocketIntegration, NormalHttpStillWorks) {
     Geruest server;
     server.addRouteWebSocket(

--- a/src/unitTests/WebSocket/WebSocketServerData_tests.cpp
+++ b/src/unitTests/WebSocket/WebSocketServerData_tests.cpp
@@ -1,0 +1,78 @@
+/**
+ * @file WebSocketServerData_tests.cpp
+ * @brief Unit tests for WebSocket route registration in ServerData.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+#include "../../data/HTTPRequest.hpp"
+#include "../../data/ServerData.hpp"
+#include "../../server/WebSocket.hpp"
+
+using namespace geruest;
+
+TEST(WebSocketServerData, AddAndFindExact) {
+    ServerData data;
+    bool called = false;
+    data.addWebSocketRoute(
+        "/ws/chat",
+        [&called](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> {
+            called = true;
+            co_return;
+        });
+    const auto handler = data.findMatchingWebSocketRoute("/ws/chat");
+    ASSERT_TRUE(handler.has_value());
+    EXPECT_FALSE(data.findMatchingWebSocketRoute("/ws/other").has_value());
+    (void)called;
+}
+
+TEST(WebSocketServerData, WildcardMatch) {
+    ServerData data;
+    data.addWebSocketRoute(
+        "/ws/*",
+        [](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> { co_return; });
+    EXPECT_TRUE(data.findMatchingWebSocketRoute("/ws/anything").has_value());
+}
+
+TEST(WebSocketServerData, ExactBeatsWildcard) {
+    ServerData data;
+    data.addWebSocketRoute(
+        "/ws/chat",
+        [](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> { co_return; });
+    data.addWebSocketRoute(
+        "/ws/*",
+        [](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> { co_return; });
+    const auto handler = data.findMatchingWebSocketRoute("/ws/chat");
+    ASSERT_TRUE(handler.has_value());
+}
+
+TEST(WebSocketServerData, NoCrossContaminationWithHttpRoutes) {
+    ServerData data;
+    data.addWebSocketRoute(
+        "/api/ws",
+        [](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> { co_return; });
+    EXPECT_FALSE(data.findMatchingRoute("/api/ws").has_value());
+    EXPECT_FALSE(data.findMatchingAsyncRoute("/api/ws").has_value());
+}
+
+TEST(WebSocketServerData, CopyPreservesRoutes) {
+    ServerData original;
+    original.addWebSocketRoute(
+        "/echo",
+        [](WebSocketConnection&, const HTTPRequest&) -> boost::asio::awaitable<void> { co_return; });
+    const ServerData copy = original;
+    EXPECT_TRUE(copy.findMatchingWebSocketRoute("/echo").has_value());
+}
+
+TEST(WebSocketServerData, LimitsAndSubprotocols) {
+    ServerData data;
+    EXPECT_EQ(data.getWebSocketLimits().maxMessageBytes, 16U * 1024 * 1024);
+    data.setWebSocketMaxFrameBytes(1024);
+    EXPECT_EQ(data.getWebSocketLimits().maxFrameBytes, 1024U);
+    data.addWebSocketSubprotocol("chat");
+    data.addWebSocketSubprotocol("v2");
+    ASSERT_EQ(data.getWebSocketSubprotocols().size(), 2U);
+    EXPECT_EQ(data.getWebSocketSubprotocols()[0], "chat");
+}


### PR DESCRIPTION
## Summary

- **WebSockets** — `addRouteWebSocket` with coroutine and callback APIs (`WebSocketConnection`, `WSMessage`), upgrade handling before redirects/HTTP routes, configurable limits/subprotocols, example chat page, docs (`WEBSOCKETS.md`), and unit/integration tests
- **HTTP connection handling** — shared `httpShouldCloseAfterResponse` / `Connection` header parsing so keep-alive and HTTP/1.0 close behavior is correct across sessions
- **Redirects with languages** — language-prefixed paths match and inherit language on internal redirect targets; documented in `REDIRECTS_AND_404.md`
- **Database configuration** — clearer docs and runtime behavior when backend is compiled in but required settings are missing (logs error, `request.database()` stays null instead of throwing)
- **Development mode** — disables text response cache (HTML/JS/CSS rebuilt every request) alongside existing dev-mode behavior
- **EmailSender** — optional RFC 822 headers (`Reply-To`, `Cc`, `Bcc`, `Message-ID`, custom headers)
- **Base64** — shared `security/Base64.hpp` used by WebSocket handshake and BasicAuth